### PR TITLE
fix: 사용자 탈퇴 시 OAuth 연결 해제 로직 추가

### DIFF
--- a/src/main/java/com/daengddang/daengdong_map/dto/response/oauth/KakaoUnlinkResponse.java
+++ b/src/main/java/com/daengddang/daengdong_map/dto/response/oauth/KakaoUnlinkResponse.java
@@ -1,0 +1,11 @@
+package com.daengddang.daengdong_map.dto.response.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class KakaoUnlinkResponse {
+
+    @JsonProperty("id")
+    private Long id;
+}

--- a/src/main/java/com/daengddang/daengdong_map/security/oauth/kakao/KakaoOAuthProperties.java
+++ b/src/main/java/com/daengddang/daengdong_map/security/oauth/kakao/KakaoOAuthProperties.java
@@ -13,8 +13,10 @@ public class KakaoOAuthProperties {
     private String clientSecret;
     private String redirectUri;
     private String scope;
+    private String adminKey;
 
     private String authorizeUri;
     private String tokenUri;
     private String userInfoUri;
+    private String unlinkUri;
 }

--- a/src/main/java/com/daengddang/daengdong_map/service/KakaoOAuthService.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/KakaoOAuthService.java
@@ -14,4 +14,8 @@ public class KakaoOAuthService {
     public KakaoOAuthUser authenticate(String code) {
         return kakaoClient.authenticate(code);
     }
+
+    public void unlinkByAdminKey(Long kakaoUserId) {
+        kakaoClient.unlinkByAdminKey(kakaoUserId);
+    }
 }

--- a/src/main/java/com/daengddang/daengdong_map/service/UserService.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/UserService.java
@@ -35,6 +35,7 @@ public class UserService {
     private final WalkRepository walkRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final AccessValidator accessValidator;
+    private final KakaoOAuthService kakaoOAuthService;
 
     @Transactional
     public UserRegisterResponse registerUserInfo(Long userId, UserRegisterRequest dto) {
@@ -120,6 +121,10 @@ public class UserService {
     @Transactional
     public void withdrawUser(Long userId) {
         User user = accessValidator.getUserOrThrow(userId);
+        Long kakaoUserId = user.getKakaoUserId();
+        if (kakaoUserId != null) {
+            kakaoOAuthService.unlinkByAdminKey(kakaoUserId);
+        }
 
         Dog dog = dogRepository.findByUser(user).orElse(null);
         if (dog != null) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -45,9 +45,11 @@ oauth:
     client-secret: ${KAKAO_CLIENT_SECRET}
     redirect-uri: ${KAKAO_REDIRECT_URI}
     scope: ${KAKAO_SCOPE:account_email}
+    admin-key: ${KAKAO_ADMIN_KEY}
     authorize-uri: https://kauth.kakao.com/oauth/authorize
     token-uri: https://kauth.kakao.com/oauth/token
     user-info-uri: https://kapi.kakao.com/v2/user/me
+    unlink-uri: https://kapi.kakao.com/v1/user/unlink
 
 
 websocket:


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 사용자 탈퇴 후 재 로그인시 OAuth 회원가입 폼 등 동의 권한을 다시 묻지 않고 바로 로그인 되는 문제를 해결
