### PR TITLE
fix: 좌표 검증 로직 공통화 및 반경 제한 추가

### DIFF
--- a/src/main/java/com/daengddang/daengdong_map/service/BlockService.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/BlockService.java
@@ -8,6 +8,7 @@ import com.daengddang.daengdong_map.dto.response.block.NearbyBlockResponse;
 import com.daengddang.daengdong_map.repository.BlockOwnershipRepository;
 import com.daengddang.daengdong_map.util.BlockIdUtil;
 import com.daengddang.daengdong_map.util.BlockOwnershipMapper;
+import com.daengddang.daengdong_map.util.CoordinateValidator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,7 +24,8 @@ public class BlockService {
 
     @Transactional(readOnly = true)
     public NearbyBlockListResponse getNearbyBlocks(Double lat, Double lng, Integer radiusMeters) {
-        if (!isValidInput(lat, lng, radiusMeters)) {
+        if (!CoordinateValidator.isValidLatLng(lat, lng)
+                || !CoordinateValidator.isValidRadius(radiusMeters)) {
             throw new BaseException(ErrorCode.INVALID_FORMAT);
         }
 
@@ -43,16 +45,6 @@ public class BlockService {
                 .toList();
 
         return NearbyBlockListResponse.from(blocks);
-    }
-
-    private boolean isValidInput(Double lat, Double lng, Integer radiusMeters) {
-        if (lat == null || lng == null || radiusMeters == null) {
-            return false;
-        }
-        if (!Double.isFinite(lat) || !Double.isFinite(lng)) {
-            return false;
-        }
-        return radiusMeters > 0;
     }
 
     private int toRange(int radiusMeters) {

--- a/src/main/java/com/daengddang/daengdong_map/service/WalkWebSocketService.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/WalkWebSocketService.java
@@ -18,6 +18,7 @@ import com.daengddang.daengdong_map.repository.BlockOwnershipRepository;
 import com.daengddang.daengdong_map.repository.BlockRepository;
 import com.daengddang.daengdong_map.repository.WalkRepository;
 import com.daengddang.daengdong_map.util.AfterCommitExecutor;
+import com.daengddang.daengdong_map.util.CoordinateValidator;
 import com.daengddang.daengdong_map.util.StayValidator;
 import com.daengddang.daengdong_map.util.WalkPointWriter;
 
@@ -53,7 +54,7 @@ public class WalkWebSocketService {
             return;
         }
 
-        if (!isValidCoordinate(payload.getLat(), payload.getLng())) {
+        if (!CoordinateValidator.isValidLatLng(payload.getLat(), payload.getLng())) {
             sendError(walkId, WebSocketErrorReason.INVALID_LOCATION.getMessage());
             return;
         }
@@ -138,13 +139,5 @@ public class WalkWebSocketService {
             messagingTemplate.convertAndSend("/topic/blocks/" + areaKey, message);
         });
     }
-
-    private boolean isValidCoordinate(double lat, double lng) {
-        if (!Double.isFinite(lat) || !Double.isFinite(lng)) {
-            return false;
-        }
-        return lat >= -90.0 && lat <= 90.0 && lng >= -180.0 && lng <= 180.0;
-    }
-
 
 }

--- a/src/main/java/com/daengddang/daengdong_map/util/CoordinateValidator.java
+++ b/src/main/java/com/daengddang/daengdong_map/util/CoordinateValidator.java
@@ -1,0 +1,30 @@
+package com.daengddang.daengdong_map.util;
+
+public final class CoordinateValidator {
+
+    public static final int MIN_RADIUS_METERS = 0;
+    public static final int MAX_RADIUS_METERS = 1500;
+
+    private CoordinateValidator() {
+    }
+
+    public static boolean isValidLatLng(Double lat, Double lng) {
+        if (lat == null || lng == null) {
+            return false;
+        }
+        return isValidLatLng(lat.doubleValue(), lng.doubleValue());
+    }
+
+    public static boolean isValidLatLng(double lat, double lng) {
+        if (!Double.isFinite(lat) || !Double.isFinite(lng)) {
+            return false;
+        }
+        return lat >= -90.0 && lat <= 90.0 && lng >= -180.0 && lng <= 180.0;
+    }
+
+    public static boolean isValidRadius(Integer radiusMeters) {
+        return radiusMeters != null
+                && radiusMeters >= MIN_RADIUS_METERS
+                && radiusMeters <= MAX_RADIUS_METERS;
+    }
+}


### PR DESCRIPTION
 ## #️⃣연관된 이슈

  #71 

  ## 📝작업 내용

  - 좌표/반경 검증을 CoordinateValidator로 공통화
  - BlockService, WalkWebSocketService에서 공통 validator 사용
  - 반경 범위를 0~1500m로 제한

  ### 스크린샷 (선택)

  없음
