### PR TITLE
feat: 블록 저장 로그 추가(산책 별 검사)

### DIFF
--- a/src/main/java/com/daengddang/daengdong_map/domain/walk/WalkBlockLog.java
+++ b/src/main/java/com/daengddang/daengdong_map/domain/walk/WalkBlockLog.java
@@ -1,0 +1,70 @@
+package com.daengddang.daengdong_map.domain.walk;
+
+import com.daengddang.daengdong_map.domain.block.Block;
+import com.daengddang.daengdong_map.domain.dog.Dog;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "walk_block_logs", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_walk_block_logs_walk_block", columnNames = {"walk_id", "block_id"})
+})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SequenceGenerator(
+        name = "walk_block_log_seq_generator",
+        sequenceName = "walk_block_logs_walk_block_log_id_seq",
+        allocationSize = 1
+)
+public class WalkBlockLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "walk_block_log_seq_generator")
+    @Column(name = "walk_block_log_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "walk_id", nullable = false)
+    private Walk walk;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "block_id", nullable = false)
+    private Block block;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "dog_id", nullable = false)
+    private Dog dog;
+
+    @Column(name = "acquired_at", nullable = false)
+    private LocalDateTime acquiredAt;
+
+    @Builder
+    private WalkBlockLog(Walk walk, Block block, Dog dog, LocalDateTime acquiredAt) {
+        this.walk = walk;
+        this.block = block;
+        this.dog = dog;
+        this.acquiredAt = acquiredAt;
+    }
+
+    @PrePersist
+    private void onCreate() {
+        if (acquiredAt == null) {
+            acquiredAt = LocalDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/daengddang/daengdong_map/dto/request/walk/WalkEndRequest.java
+++ b/src/main/java/com/daengddang/daengdong_map/dto/request/walk/WalkEndRequest.java
@@ -25,6 +25,9 @@ public class WalkEndRequest {
     @NotNull
     private WalkStatus status;
 
+    @NotNull
+    private Boolean isValidated;
+
     public static WalkPoint of(WalkEndRequest dto, Walk walk, LocalDateTime recordedAt) {
         return WalkPoint.builder()
                 .walk(walk)

--- a/src/main/java/com/daengddang/daengdong_map/repository/WalkBlockLogRepository.java
+++ b/src/main/java/com/daengddang/daengdong_map/repository/WalkBlockLogRepository.java
@@ -1,0 +1,31 @@
+package com.daengddang.daengdong_map.repository;
+
+import com.daengddang.daengdong_map.domain.walk.WalkBlockLog;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface WalkBlockLogRepository extends JpaRepository<WalkBlockLog, Long> {
+
+    @Modifying
+    @Query(value = """
+            INSERT INTO walk_block_logs (walk_id, block_id, dog_id, acquired_at)
+            VALUES (:walkId, :blockId, :dogId, :acquiredAt)
+            ON CONFLICT (walk_id, block_id) DO NOTHING
+            """, nativeQuery = true)
+    void insertIfNotExists(
+            @Param("walkId") Long walkId,
+            @Param("blockId") Long blockId,
+            @Param("dogId") Long dogId,
+            @Param("acquiredAt") java.time.LocalDateTime acquiredAt
+    );
+
+    @Query("""
+            select log.block.id
+            from WalkBlockLog log
+            where log.walk.id = :walkId
+            """)
+    List<Long> findBlockIdsByWalkId(@Param("walkId") Long walkId);
+}


### PR DESCRIPTION
  ## #️⃣연관된 이슈

  #91 

  ## 📝작업 내용

  - 산책 중 점유 블록을 기록하는 walk_block_logs 테이블/엔티티/레포지토리 추가
  - 점유/탈취 시 로그 기록, endWalk에서 isValidated 기준으로 점유 블록 회수
  - Walk 종료 DTO에 isValidated 추가

  ### 스크린샷 (선택)

 

  ## 💬리뷰 요구사항(선택)

