### PR TITLE
fix: WebSocket 서비스 책임 분리

### DIFF
--- a/src/main/java/com/daengddang/daengdong_map/config/WebSocketConfig.java
+++ b/src/main/java/com/daengddang/daengdong_map/config/WebSocketConfig.java
@@ -7,6 +7,7 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 import com.daengddang.daengdong_map.websocket.WebSocketChannelInterceptor;
+import com.daengddang.daengdong_map.websocket.WebSocketDestinations;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -18,14 +19,14 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws/walks")
+        registry.addEndpoint(WebSocketDestinations.WS_ENDPOINT)
                 .setAllowedOriginPatterns("*");
     }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.setApplicationDestinationPrefixes("/app");
-        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes(WebSocketDestinations.APP_PREFIX);
+        registry.enableSimpleBroker(WebSocketDestinations.TOPIC_PREFIX);
     }
 
     @Override

--- a/src/main/java/com/daengddang/daengdong_map/controller/WalkWebSocketController.java
+++ b/src/main/java/com/daengddang/daengdong_map/controller/WalkWebSocketController.java
@@ -4,7 +4,9 @@ import com.daengddang.daengdong_map.dto.websocket.common.WebSocketEventType;
 import com.daengddang.daengdong_map.dto.websocket.common.WebSocketMessage;
 import com.daengddang.daengdong_map.dto.websocket.common.WebSocketErrorReason;
 import com.daengddang.daengdong_map.dto.websocket.inbound.LocationUpdatePayload;
+import com.daengddang.daengdong_map.util.WalkEventPublisher;
 import com.daengddang.daengdong_map.service.WalkWebSocketService;
+import com.daengddang.daengdong_map.websocket.WebSocketDestinations;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
@@ -16,19 +18,20 @@ import org.springframework.stereotype.Controller;
 public class WalkWebSocketController {
 
     private final WalkWebSocketService walkWebSocketService;
+    private final WalkEventPublisher walkEventPublisher;
 
-    @MessageMapping("/walks/{walkId}/location")
+    @MessageMapping(WebSocketDestinations.WALK_LOCATION)
     public void handleLocationUpdate(
             @DestinationVariable Long walkId,
             WebSocketMessage<LocationUpdatePayload> message,
             Principal principal
     ) {
         if (message == null || message.getData() == null) {
-            walkWebSocketService.sendError(walkId, WebSocketErrorReason.INVALID_LOCATION.getMessage());
+            walkEventPublisher.sendError(walkId, WebSocketErrorReason.INVALID_LOCATION.getMessage());
             return;
         }
         if (message.getType() != null && message.getType() != WebSocketEventType.LOCATION_UPDATE) {
-            walkWebSocketService.sendError(walkId, WebSocketErrorReason.INVALID_EVENT_TYPE.getMessage());
+            walkEventPublisher.sendError(walkId, WebSocketErrorReason.INVALID_EVENT_TYPE.getMessage());
             return;
         }
 

--- a/src/main/java/com/daengddang/daengdong_map/service/BlockOccupancyService.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/BlockOccupancyService.java
@@ -1,0 +1,56 @@
+package com.daengddang.daengdong_map.service;
+
+import com.daengddang.daengdong_map.domain.block.Block;
+import com.daengddang.daengdong_map.domain.block.BlockOwnership;
+import com.daengddang.daengdong_map.domain.dog.Dog;
+import com.daengddang.daengdong_map.domain.walk.Walk;
+import com.daengddang.daengdong_map.repository.BlockOwnershipRepository;
+import com.daengddang.daengdong_map.repository.BlockRepository;
+import com.daengddang.daengdong_map.repository.WalkBlockLogRepository;
+import java.time.LocalDateTime;
+
+import com.daengddang.daengdong_map.util.BlockOccupancyResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BlockOccupancyService {
+
+    private final BlockRepository blockRepository;
+    private final BlockOwnershipRepository blockOwnershipRepository;
+    private final WalkBlockLogRepository walkBlockLogRepository;
+
+    @Transactional
+    public BlockOccupancyResult occupy(Walk walk, int blockX, int blockY, LocalDateTime timestamp) {
+        Dog dog = walk.getDog();
+
+        blockRepository.insertIfNotExists(blockX, blockY);
+        Block block = blockRepository.findByXAndY(blockX, blockY)
+                .orElseThrow();
+
+        BlockOwnership ownership = blockOwnershipRepository.findById(block.getId()).orElse(null);
+        if (ownership == null) {
+            BlockOwnership newOwnership = BlockOwnership.builder()
+                    .block(block)
+                    .dog(dog)
+                    .acquiredAt(timestamp)
+                    .lastPassedAt(timestamp)
+                    .build();
+            blockOwnershipRepository.save(newOwnership);
+            walkBlockLogRepository.insertIfNotExists(walk.getId(), block.getId(), dog.getId(), timestamp);
+            return BlockOccupancyResult.occupied();
+        }
+
+        if (ownership.getDog().getId().equals(dog.getId())) {
+            ownership.updateLastPassedAt(timestamp);
+            return BlockOccupancyResult.alreadyOwned();
+        }
+
+        Long previousDogId = ownership.getDog().getId();
+        ownership.updateOwner(dog, timestamp);
+        walkBlockLogRepository.insertIfNotExists(walk.getId(), block.getId(), dog.getId(), timestamp);
+        return BlockOccupancyResult.taken(previousDogId);
+    }
+}

--- a/src/main/java/com/daengddang/daengdong_map/service/BlockSyncService.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/BlockSyncService.java
@@ -6,6 +6,7 @@ import com.daengddang.daengdong_map.dto.websocket.common.WebSocketMessage;
 import com.daengddang.daengdong_map.dto.websocket.outbound.BlockSyncEntry;
 import com.daengddang.daengdong_map.dto.websocket.outbound.BlocksSyncPayload;
 import com.daengddang.daengdong_map.repository.BlockOwnershipRepository;
+import com.daengddang.daengdong_map.websocket.WebSocketDestinations;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -75,7 +76,8 @@ public class BlockSyncService {
         WebSocketMessage<BlocksSyncPayload> message =
                 new WebSocketMessage<>(WebSocketEventType.BLOCKS_SYNC, payload,
                         WebSocketEventType.BLOCKS_SYNC.getMessage());
-        afterCommitExecutor.sendAfterCommit(() -> messagingTemplate.convertAndSend("/topic/blocks/" + areaKey, message));
+        afterCommitExecutor.sendAfterCommit(() ->
+                messagingTemplate.convertAndSend(WebSocketDestinations.blocks(areaKey), message));
     }
 
     private AreaRange toAreaRange(int blockX, int blockY) {

--- a/src/main/java/com/daengddang/daengdong_map/service/WalkWebSocketService.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/WalkWebSocketService.java
@@ -1,32 +1,14 @@
 package com.daengddang.daengdong_map.service;
 
-import com.daengddang.daengdong_map.util.BlockIdUtil;
-import com.daengddang.daengdong_map.dto.websocket.common.WebSocketEventType;
-import com.daengddang.daengdong_map.dto.websocket.common.WebSocketMessage;
+import com.daengddang.daengdong_map.util.*;
 import com.daengddang.daengdong_map.dto.websocket.common.WebSocketErrorReason;
 import com.daengddang.daengdong_map.dto.websocket.inbound.LocationUpdatePayload;
-import com.daengddang.daengdong_map.dto.websocket.outbound.BlockOccupiedPayload;
-import com.daengddang.daengdong_map.dto.websocket.outbound.BlockOccupyFailReason;
-import com.daengddang.daengdong_map.dto.websocket.outbound.BlockOccupyFailedPayload;
-import com.daengddang.daengdong_map.dto.websocket.outbound.BlockTakenPayload;
-import com.daengddang.daengdong_map.domain.block.Block;
-import com.daengddang.daengdong_map.domain.block.BlockOwnership;
-import com.daengddang.daengdong_map.domain.dog.Dog;
 import com.daengddang.daengdong_map.domain.walk.Walk;
-import com.daengddang.daengdong_map.domain.walk.WalkStatus;
-import com.daengddang.daengdong_map.repository.BlockOwnershipRepository;
-import com.daengddang.daengdong_map.repository.BlockRepository;
-import com.daengddang.daengdong_map.repository.WalkBlockLogRepository;
-import com.daengddang.daengdong_map.repository.WalkRepository;
-import com.daengddang.daengdong_map.util.AfterCommitExecutor;
-import com.daengddang.daengdong_map.util.CoordinateValidator;
-import com.daengddang.daengdong_map.util.StayValidator;
-import com.daengddang.daengdong_map.util.WalkPointWriter;
 
 import java.time.LocalDateTime;
 import java.security.Principal;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,30 +16,25 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class WalkWebSocketService {
 
-    private final SimpMessagingTemplate messagingTemplate;
-    private final WalkRepository walkRepository;
-    private final BlockRepository blockRepository;
-    private final BlockOwnershipRepository blockOwnershipRepository;
-    private final WalkBlockLogRepository walkBlockLogRepository;
+    private final WalkSessionValidator walkSessionValidator;
+    private final BlockOccupancyService blockOccupancyService;
+    private final WalkEventPublisher walkEventPublisher;
     private final WalkPointWriter walkPointWriter;
     private final StayValidator stayValidator;
     private final BlockSyncService blockSyncService;
-    private final AfterCommitExecutor afterCommitExecutor;
 
     @Transactional
     public void handleLocationUpdate(Long walkId, LocationUpdatePayload payload, Principal principal) {
         LocalDateTime timestamp = LocalDateTime.now();
 
-        Walk walk = walkRepository.findById(walkId)
-                .orElse(null);
-
-        if (walk == null || walk.getStatus() != WalkStatus.IN_PROGRESS) {
-            sendError(walkId, WebSocketErrorReason.INVALID_WALK_SESSION.getMessage());
+        Walk walk = walkSessionValidator.getActiveWalkOrNull(walkId);
+        if (walk == null) {
+            walkEventPublisher.sendError(walkId, WebSocketErrorReason.INVALID_WALK_SESSION.getMessage());
             return;
         }
 
-        if (!CoordinateValidator.isValidLatLng(payload.getLat(), payload.getLng())) {
-            sendError(walkId, WebSocketErrorReason.INVALID_LOCATION.getMessage());
+        if (!walkSessionValidator.isValidCoordinate(payload.getLat(), payload.getLng())) {
+            walkEventPublisher.sendError(walkId, WebSocketErrorReason.INVALID_LOCATION.getMessage());
             return;
         }
 
@@ -70,76 +47,29 @@ public class WalkWebSocketService {
         boolean staySatisfied = stayValidator.isStaySatisfied(walkId, blockId, timestamp);
 
         if (!staySatisfied) {
-            BlockOccupyFailedPayload failPayload =
-                    BlockOccupyFailedPayload.from(BlockOccupyFailReason.INSUFFICIENT_STAY_TIME);
-
-            WebSocketMessage<BlockOccupyFailedPayload> message =
-                    new WebSocketMessage<>(WebSocketEventType.BLOCK_OCCUPY_FAILED, failPayload,
-                            WebSocketEventType.BLOCK_OCCUPY_FAILED.getMessage());
-
-            messagingTemplate.convertAndSend("/topic/walks/" + walkId, message);
-            blockSyncService.syncBlocksOnAreaChange(walkId, blockX, blockY, areaKey, timestamp);
+            walkEventPublisher.sendOccupyFailed(walkId, blockX, blockY, areaKey, timestamp);
             return;
         }
 
-        Dog dog = walk.getDog();
-        blockRepository.insertIfNotExists(blockX, blockY);
-        Block block = blockRepository.findByXAndY(blockX, blockY)
-                .orElseThrow();
-
-        BlockOwnership ownership = blockOwnershipRepository.findById(block.getId()).orElse(null);
-        if (ownership == null) {
-            BlockOwnership newOwnership = BlockOwnership.builder()
-                    .block(block)
-                    .dog(dog)
-                    .acquiredAt(timestamp)
-                    .lastPassedAt(timestamp)
-                    .build();
-            blockOwnershipRepository.save(newOwnership);
-            walkBlockLogRepository.insertIfNotExists(walk.getId(), block.getId(), dog.getId(), timestamp);
-            sendBlockOccupied(walkId, blockId, dog, timestamp, areaKey);
-            blockSyncService.syncBlocks(walkId, blockX, blockY, areaKey, timestamp);
-            return;
+        BlockOccupancyResult result = blockOccupancyService.occupy(walk, blockX, blockY, timestamp);
+        switch (result.type()) {
+            case OCCUPIED -> {
+                walkEventPublisher.sendBlockOccupied(walkId, blockId, walk.getDog(), timestamp, areaKey);
+                walkEventPublisher.syncBlocks(walkId, blockX, blockY, areaKey, timestamp);
+            }
+            case TAKEN -> {
+                walkEventPublisher.sendBlockTaken(
+                        walkId,
+                        blockId,
+                        result.previousDogId(),
+                        walk.getDog().getId(),
+                        timestamp,
+                        areaKey
+                );
+                walkEventPublisher.syncBlocks(walkId, blockX, blockY, areaKey, timestamp);
+            }
+            case ALREADY_OWNED -> walkEventPublisher.syncBlocksOnAreaChange(walkId, blockX, blockY, areaKey, timestamp);
         }
-
-        if (ownership.getDog().getId().equals(dog.getId())) {
-            ownership.updateLastPassedAt(timestamp);
-            blockSyncService.syncBlocksOnAreaChange(walkId, blockX, blockY, areaKey, timestamp);
-            return;
-        }
-
-        Long previousDogId = ownership.getDog().getId();
-        ownership.updateOwner(dog, timestamp);
-        walkBlockLogRepository.insertIfNotExists(walk.getId(), block.getId(), dog.getId(), timestamp);
-        sendBlockTaken(walkId, blockId, previousDogId, dog.getId(), timestamp, areaKey);
-        blockSyncService.syncBlocks(walkId, blockX, blockY, areaKey, timestamp);
-    }
-
-    public void sendError(Long walkId, String message) {
-        messagingTemplate.convertAndSend("/topic/walks/" + walkId, WebSocketMessage.error(message));
-    }
-
-    private void sendBlockOccupied(Long walkId, String blockId, Dog dog, LocalDateTime occupiedAt, String areaKey) {
-        BlockOccupiedPayload payload = BlockOccupiedPayload.from(blockId, dog.getId(), dog.getName(), occupiedAt);
-        WebSocketMessage<BlockOccupiedPayload> message =
-                new WebSocketMessage<>(WebSocketEventType.BLOCK_OCCUPIED, payload,
-                        WebSocketEventType.BLOCK_OCCUPIED.getMessage());
-        afterCommitExecutor.sendAfterCommit(() -> {
-            messagingTemplate.convertAndSend("/topic/walks/" + walkId, message);
-            messagingTemplate.convertAndSend("/topic/blocks/" + areaKey, message);
-        });
-    }
-
-    private void sendBlockTaken(Long walkId, String blockId, Long previousDogId, Long newDogId,
-                                LocalDateTime takenAt, String areaKey) {
-        BlockTakenPayload payload = BlockTakenPayload.from(blockId, previousDogId, newDogId, takenAt);
-        WebSocketMessage<BlockTakenPayload> message =
-                new WebSocketMessage<>(WebSocketEventType.BLOCK_TAKEN, payload,
-                        WebSocketEventType.BLOCK_TAKEN.getMessage());
-        afterCommitExecutor.sendAfterCommit(() -> {
-            messagingTemplate.convertAndSend("/topic/walks/" + walkId, message);
-            messagingTemplate.convertAndSend("/topic/blocks/" + areaKey, message);
-        });
     }
 
 }

--- a/src/main/java/com/daengddang/daengdong_map/util/BlockOccupancyResult.java
+++ b/src/main/java/com/daengddang/daengdong_map/util/BlockOccupancyResult.java
@@ -1,0 +1,22 @@
+package com.daengddang.daengdong_map.util;
+
+public record BlockOccupancyResult(Type type, Long previousDogId) {
+
+    public enum Type {
+        OCCUPIED,
+        TAKEN,
+        ALREADY_OWNED
+    }
+
+    public static BlockOccupancyResult occupied() {
+        return new BlockOccupancyResult(Type.OCCUPIED, null);
+    }
+
+    public static BlockOccupancyResult taken(Long previousDogId) {
+        return new BlockOccupancyResult(Type.TAKEN, previousDogId);
+    }
+
+    public static BlockOccupancyResult alreadyOwned() {
+        return new BlockOccupancyResult(Type.ALREADY_OWNED, null);
+    }
+}

--- a/src/main/java/com/daengddang/daengdong_map/util/WalkEventPublisher.java
+++ b/src/main/java/com/daengddang/daengdong_map/util/WalkEventPublisher.java
@@ -1,0 +1,71 @@
+package com.daengddang.daengdong_map.util;
+
+import com.daengddang.daengdong_map.dto.websocket.common.WebSocketEventType;
+import com.daengddang.daengdong_map.dto.websocket.common.WebSocketMessage;
+import com.daengddang.daengdong_map.dto.websocket.outbound.BlockOccupiedPayload;
+import com.daengddang.daengdong_map.dto.websocket.outbound.BlockOccupyFailReason;
+import com.daengddang.daengdong_map.dto.websocket.outbound.BlockOccupyFailedPayload;
+import com.daengddang.daengdong_map.dto.websocket.outbound.BlockTakenPayload;
+import com.daengddang.daengdong_map.domain.dog.Dog;
+import com.daengddang.daengdong_map.service.BlockSyncService;
+import com.daengddang.daengdong_map.websocket.WebSocketDestinations;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WalkEventPublisher {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final BlockSyncService blockSyncService;
+    private final AfterCommitExecutor afterCommitExecutor;
+
+    public void sendError(Long walkId, String message) {
+        messagingTemplate.convertAndSend(WebSocketDestinations.walk(walkId), WebSocketMessage.error(message));
+    }
+
+    public void sendOccupyFailed(Long walkId, int blockX, int blockY, String areaKey, LocalDateTime timestamp) {
+        BlockOccupyFailedPayload failPayload =
+                BlockOccupyFailedPayload.from(BlockOccupyFailReason.INSUFFICIENT_STAY_TIME);
+
+        WebSocketMessage<BlockOccupyFailedPayload> message =
+                new WebSocketMessage<>(WebSocketEventType.BLOCK_OCCUPY_FAILED, failPayload,
+                        WebSocketEventType.BLOCK_OCCUPY_FAILED.getMessage());
+
+        messagingTemplate.convertAndSend(WebSocketDestinations.walk(walkId), message);
+        blockSyncService.syncBlocksOnAreaChange(walkId, blockX, blockY, areaKey, timestamp);
+    }
+
+    public void sendBlockOccupied(Long walkId, String blockId, Dog dog, LocalDateTime occupiedAt, String areaKey) {
+        BlockOccupiedPayload payload = BlockOccupiedPayload.from(blockId, dog.getId(), dog.getName(), occupiedAt);
+        WebSocketMessage<BlockOccupiedPayload> message =
+                new WebSocketMessage<>(WebSocketEventType.BLOCK_OCCUPIED, payload,
+                        WebSocketEventType.BLOCK_OCCUPIED.getMessage());
+        afterCommitExecutor.sendAfterCommit(() -> {
+            messagingTemplate.convertAndSend(WebSocketDestinations.walk(walkId), message);
+            messagingTemplate.convertAndSend(WebSocketDestinations.blocks(areaKey), message);
+        });
+    }
+
+    public void sendBlockTaken(Long walkId, String blockId, Long previousDogId, Long newDogId,
+                                LocalDateTime takenAt, String areaKey) {
+        BlockTakenPayload payload = BlockTakenPayload.from(blockId, previousDogId, newDogId, takenAt);
+        WebSocketMessage<BlockTakenPayload> message =
+                new WebSocketMessage<>(WebSocketEventType.BLOCK_TAKEN, payload,
+                        WebSocketEventType.BLOCK_TAKEN.getMessage());
+        afterCommitExecutor.sendAfterCommit(() -> {
+            messagingTemplate.convertAndSend(WebSocketDestinations.walk(walkId), message);
+            messagingTemplate.convertAndSend(WebSocketDestinations.blocks(areaKey), message);
+        });
+    }
+
+    public void syncBlocks(Long walkId, int blockX, int blockY, String areaKey, LocalDateTime timestamp) {
+        blockSyncService.syncBlocks(walkId, blockX, blockY, areaKey, timestamp);
+    }
+
+    public void syncBlocksOnAreaChange(Long walkId, int blockX, int blockY, String areaKey, LocalDateTime timestamp) {
+        blockSyncService.syncBlocksOnAreaChange(walkId, blockX, blockY, areaKey, timestamp);
+    }
+}

--- a/src/main/java/com/daengddang/daengdong_map/util/WalkSessionValidator.java
+++ b/src/main/java/com/daengddang/daengdong_map/util/WalkSessionValidator.java
@@ -1,0 +1,26 @@
+package com.daengddang.daengdong_map.util;
+
+import com.daengddang.daengdong_map.domain.walk.Walk;
+import com.daengddang.daengdong_map.domain.walk.WalkStatus;
+import com.daengddang.daengdong_map.repository.WalkRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WalkSessionValidator {
+
+    private final WalkRepository walkRepository;
+
+    public Walk getActiveWalkOrNull(Long walkId) {
+        Walk walk = walkRepository.findById(walkId).orElse(null);
+        if (walk == null || walk.getStatus() != WalkStatus.IN_PROGRESS) {
+            return null;
+        }
+        return walk;
+    }
+
+    public boolean isValidCoordinate(double lat, double lng) {
+        return CoordinateValidator.isValidLatLng(lat, lng);
+    }
+}

--- a/src/main/java/com/daengddang/daengdong_map/websocket/WalkWebSocketEventListener.java
+++ b/src/main/java/com/daengddang/daengdong_map/websocket/WalkWebSocketEventListener.java
@@ -12,12 +12,14 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import com.daengddang.daengdong_map.websocket.WebSocketDestinations;
 
 @Component
 @RequiredArgsConstructor
 public class WalkWebSocketEventListener {
 
-    private static final Pattern WALK_TOPIC_PATTERN = Pattern.compile("^/topic/walks/(\\d+)$");
+    private static final Pattern WALK_TOPIC_PATTERN =
+            Pattern.compile("^" + WebSocketDestinations.WALKS_PREFIX + "(\\d+)$");
 
     private final SimpMessagingTemplate messagingTemplate;
 

--- a/src/main/java/com/daengddang/daengdong_map/websocket/WebSocketDestinations.java
+++ b/src/main/java/com/daengddang/daengdong_map/websocket/WebSocketDestinations.java
@@ -1,0 +1,23 @@
+package com.daengddang.daengdong_map.websocket;
+
+public final class WebSocketDestinations {
+
+    public static final String APP_PREFIX = "/app";
+    public static final String WS_ENDPOINT = "/ws/walks";
+    public static final String WALK_LOCATION = "/walks/{walkId}/location";
+
+    public static final String TOPIC_PREFIX = "/topic";
+    public static final String WALKS_PREFIX = TOPIC_PREFIX + "/walks/";
+    public static final String BLOCKS_PREFIX = TOPIC_PREFIX + "/blocks/";
+
+    private WebSocketDestinations() {
+    }
+
+    public static String walk(Long walkId) {
+        return WALKS_PREFIX + walkId;
+    }
+
+    public static String blocks(String areaKey) {
+        return BLOCKS_PREFIX + areaKey;
+    }
+}


### PR DESCRIPTION
  ## #️⃣연관된 이슈

   #95 #96 

  ## 📝작업 내용
  - WalkWebSocketService의 책임을 분리하여 세션 검증/점유 처리/이벤트 발행을 각각 서비스로 분리
  - 기존 로직은 유지하고 오케스트레이션 역할만 남김
  - 관련 의존성 정리 및 호출 흐름 재구성
