### PR TITLE
fix: 비정상유저 블록 점유 취소시 이전 소유자로 복구

### DIFF
--- a/src/main/java/com/daengddang/daengdong_map/domain/walk/WalkBlockLog.java
+++ b/src/main/java/com/daengddang/daengdong_map/domain/walk/WalkBlockLog.java
@@ -50,14 +50,22 @@ public class WalkBlockLog {
     @JoinColumn(name = "dog_id", nullable = false)
     private Dog dog;
 
+    @Column(name = "previous_dog_id")
+    private Long previousDogId;
+
     @Column(name = "acquired_at", nullable = false)
     private LocalDateTime acquiredAt;
 
     @Builder
-    private WalkBlockLog(Walk walk, Block block, Dog dog, LocalDateTime acquiredAt) {
+    private WalkBlockLog(Walk walk,
+                         Block block,
+                         Dog dog,
+                         Long previousDogId,
+                         LocalDateTime acquiredAt) {
         this.walk = walk;
         this.block = block;
         this.dog = dog;
+        this.previousDogId = previousDogId;
         this.acquiredAt = acquiredAt;
     }
 

--- a/src/main/java/com/daengddang/daengdong_map/repository/BlockOwnershipRepository.java
+++ b/src/main/java/com/daengddang/daengdong_map/repository/BlockOwnershipRepository.java
@@ -5,6 +5,7 @@ import com.daengddang.daengdong_map.domain.dog.Dog;
 import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -36,5 +37,20 @@ public interface BlockOwnershipRepository extends JpaRepository<BlockOwnership, 
             @Param("maxX") int maxX,
             @Param("minY") int minY,
             @Param("maxY") int maxY
+    );
+
+    @Modifying
+    @Query(value = """
+            UPDATE block_ownership
+            SET dog_id = :dogId,
+                acquired_at = :updatedAt,
+                last_passed_at = :updatedAt,
+                updated_at = :updatedAt
+            WHERE block_id = :blockId
+            """, nativeQuery = true)
+    void restoreOwner(
+            @Param("blockId") Long blockId,
+            @Param("dogId") Long dogId,
+            @Param("updatedAt") java.time.LocalDateTime updatedAt
     );
 }

--- a/src/main/java/com/daengddang/daengdong_map/repository/WalkBlockLogRepository.java
+++ b/src/main/java/com/daengddang/daengdong_map/repository/WalkBlockLogRepository.java
@@ -11,21 +11,22 @@ public interface WalkBlockLogRepository extends JpaRepository<WalkBlockLog, Long
 
     @Modifying
     @Query(value = """
-            INSERT INTO walk_block_logs (walk_id, block_id, dog_id, acquired_at)
-            VALUES (:walkId, :blockId, :dogId, :acquiredAt)
+            INSERT INTO walk_block_logs (walk_id, block_id, dog_id, previous_dog_id, acquired_at)
+            VALUES (:walkId, :blockId, :dogId, :previousDogId, :acquiredAt)
             ON CONFLICT (walk_id, block_id) DO NOTHING
             """, nativeQuery = true)
     void insertIfNotExists(
             @Param("walkId") Long walkId,
             @Param("blockId") Long blockId,
             @Param("dogId") Long dogId,
+            @Param("previousDogId") Long previousDogId,
             @Param("acquiredAt") java.time.LocalDateTime acquiredAt
     );
 
     @Query("""
-            select log.block.id
+            select log.block.id as blockId, log.previousDogId as previousDogId
             from WalkBlockLog log
             where log.walk.id = :walkId
             """)
-    List<Long> findBlockIdsByWalkId(@Param("walkId") Long walkId);
+    List<WalkBlockRestoreEntry> findRestoreEntriesByWalkId(@Param("walkId") Long walkId);
 }

--- a/src/main/java/com/daengddang/daengdong_map/repository/WalkBlockRestoreEntry.java
+++ b/src/main/java/com/daengddang/daengdong_map/repository/WalkBlockRestoreEntry.java
@@ -1,0 +1,8 @@
+package com.daengddang.daengdong_map.repository;
+
+public interface WalkBlockRestoreEntry {
+
+    Long getBlockId();
+
+    Long getPreviousDogId();
+}

--- a/src/main/java/com/daengddang/daengdong_map/service/BlockOccupancyService.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/BlockOccupancyService.java
@@ -39,7 +39,7 @@ public class BlockOccupancyService {
                     .lastPassedAt(timestamp)
                     .build();
             blockOwnershipRepository.save(newOwnership);
-            walkBlockLogRepository.insertIfNotExists(walk.getId(), block.getId(), dog.getId(), timestamp);
+            walkBlockLogRepository.insertIfNotExists(walk.getId(), block.getId(), dog.getId(), null, timestamp);
             return BlockOccupancyResult.occupied();
         }
 
@@ -50,7 +50,7 @@ public class BlockOccupancyService {
 
         Long previousDogId = ownership.getDog().getId();
         ownership.updateOwner(dog, timestamp);
-        walkBlockLogRepository.insertIfNotExists(walk.getId(), block.getId(), dog.getId(), timestamp);
+        walkBlockLogRepository.insertIfNotExists(walk.getId(), block.getId(), dog.getId(), previousDogId, timestamp);
         return BlockOccupancyResult.taken(previousDogId);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

>  x

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 블록 비정상적으로 점유시 이전 유저 소유권으로 변경

