### PR TITLE
fix: count 쿼리 사용해 조회 최적

### DIFF
--- a/src/main/java/com/daengddang/daengdong_map/repository/BlockOwnershipRepository.java
+++ b/src/main/java/com/daengddang/daengdong_map/repository/BlockOwnershipRepository.java
@@ -13,6 +13,8 @@ public interface BlockOwnershipRepository extends JpaRepository<BlockOwnership, 
 
     List<BlockOwnership> findAllByDog(Dog dog);
 
+    long countByDog(Dog dog);
+
     @Query("""
             select ownership
             from BlockOwnership ownership

--- a/src/main/java/com/daengddang/daengdong_map/service/WalkService.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/WalkService.java
@@ -102,7 +102,7 @@ public class WalkService {
             removeBlocksAcquiredInWalk(walk.getId());
         }
 
-        int occupiedBlockCount = blockOwnershipRepository.findAllByDog(dog).size();
+        int occupiedBlockCount = Math.toIntExact(blockOwnershipRepository.countByDog(dog));
 
         return WalkEndResponse.from(
                 walk.getId(),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,6 +17,7 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
+        generate_statistics: true
 
   servlet:
     multipart:


### PR DESCRIPTION
  ## #️⃣연관된 이슈
  > ex) #이슈번호, #이슈번호
  - #101  #102 

  ## 📝작업 내용
  > 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
  - Walk 종료 시 소유 블록 개수 계산 로직을 `findAllByDog().size()`에서 `countByDog()` 쿼리로 변경
  - 불필요한 엔티티 로딩 제거 및 DB I/O 감소

  ### 전후 로그 비교

#### 수정 전
```sql
  select
      bo1_0.block_id,
      bo1_0.acquired_at,
      bo1_0.created_at,
      bo1_0.dog_id,
      bo1_0.last_passed_at,
      bo1_0.updated_at
  from
      block_ownership bo1_0
  where
      bo1_0.dog_id=?
```

#### 수정 후
```sql
  select
      count(bo1_0.block_id)
  from
      block_ownership bo1_0
  where
      bo1_0.dog_id=?
```