### PR TITLE
fix: 블록 점유 쿼리 감소 (RETURNING 적용)

### DIFF
--- a/src/main/java/com/daengddang/daengdong_map/repository/BlockNativeRepository.java
+++ b/src/main/java/com/daengddang/daengdong_map/repository/BlockNativeRepository.java
@@ -1,0 +1,6 @@
+package com.daengddang.daengdong_map.repository;
+
+public interface BlockNativeRepository {
+
+    Long insertIfNotExistsReturningId(int x, int y);
+}

--- a/src/main/java/com/daengddang/daengdong_map/repository/BlockRepository.java
+++ b/src/main/java/com/daengddang/daengdong_map/repository/BlockRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface BlockRepository extends JpaRepository<Block, Long> {
+public interface BlockRepository extends JpaRepository<Block, Long>, BlockNativeRepository {
 
     Optional<Block> findByXAndY(Integer x, Integer y);
 

--- a/src/main/java/com/daengddang/daengdong_map/repository/BlockRepositoryImpl.java
+++ b/src/main/java/com/daengddang/daengdong_map/repository/BlockRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.daengddang.daengdong_map.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class BlockRepositoryImpl implements BlockNativeRepository {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public Long insertIfNotExistsReturningId(int x, int y) {
+        Query query = entityManager.createNativeQuery("""
+                INSERT INTO blocks (x, y, created_at)
+                VALUES (:x, :y, NOW())
+                ON CONFLICT (x, y) DO UPDATE
+                SET created_at = blocks.created_at
+                RETURNING block_id
+                """);
+        query.setParameter("x", x);
+        query.setParameter("y", y);
+        Object result = query.getSingleResult();
+        return ((Number) result).longValue();
+    }
+}


### PR DESCRIPTION
  ## #️⃣연관된 이슈

  > #106 #107 

  ## 📝작업 내용

  > 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

  - blocks 생성 시 `INSERT ... ON CONFLICT ... RETURNING`사용으로  기존`findByXAndY` 쿼리를 제거
  > 이를 위해 native 쿼리 전용 레포지토리 인터페이스/구현

  ### 스크린샷 (선택)

  ## 💬리뷰 요구사항(선택)

  > 없음
