### PR TITLE
fix: 블록 점유 쿼리 최적화를 위한 Dto Projection 적용

### DIFF
--- a/src/main/java/com/daengddang/daengdong_map/repository/BlockOwnershipRepository.java
+++ b/src/main/java/com/daengddang/daengdong_map/repository/BlockOwnershipRepository.java
@@ -2,6 +2,7 @@ package com.daengddang.daengdong_map.repository;
 
 import com.daengddang.daengdong_map.domain.block.BlockOwnership;
 import com.daengddang.daengdong_map.domain.dog.Dog;
+import com.daengddang.daengdong_map.repository.projection.BlockOwnershipView;
 import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,25 +17,35 @@ public interface BlockOwnershipRepository extends JpaRepository<BlockOwnership, 
     long countByDog(Dog dog);
 
     @Query("""
-            select ownership
+            select
+                ownership.id as blockId,
+                block.x as blockX,
+                block.y as blockY,
+                dog.id as dogId,
+                ownership.acquiredAt as acquiredAt
             from BlockOwnership ownership
-            join fetch ownership.block block
-            join fetch ownership.dog dog
+            join ownership.block block
+            join ownership.dog dog
             where ownership.dog = :dog
             """)
-    List<BlockOwnership> findAllByDogWithBlockAndDog(@Param("dog") Dog dog);
+    List<BlockOwnershipView> findAllByDogWithBlockAndDog(@Param("dog") Dog dog);
 
     List<BlockOwnership> findAllByIdIn(Collection<Long> blockIds);
 
     @Query("""
-            select ownership
-            from BlockOwnership ownership
-            join fetch ownership.block block
-            join fetch ownership.dog dog
-            where block.x between :minX and :maxX
-              and block.y between :minY and :maxY
+            SELECT
+                ownership.id as blockId,
+                block.x as blockX,
+                block.y as blockY,
+                dog.id as dogId,
+                ownership.acquiredAt as acquiredAt
+            FROM BlockOwnership ownership
+            JOIN ownership.block block
+            JOIN ownership.dog dog
+            WHERE block.x BETWEEN :minX AND :maxX
+              AND block.y BETWEEN :minY AND :maxY
             """)
-    List<BlockOwnership> findAllByBlockRange(
+    List<BlockOwnershipView> findAllByBlockRange(
             @Param("minX") int minX,
             @Param("maxX") int maxX,
             @Param("minY") int minY,

--- a/src/main/java/com/daengddang/daengdong_map/repository/projection/BlockOwnershipView.java
+++ b/src/main/java/com/daengddang/daengdong_map/repository/projection/BlockOwnershipView.java
@@ -1,0 +1,16 @@
+package com.daengddang.daengdong_map.repository.projection;
+
+import java.time.LocalDateTime;
+
+public interface BlockOwnershipView {
+
+    Long getBlockId();
+
+    Integer getBlockX();
+
+    Integer getBlockY();
+
+    Long getDogId();
+
+    LocalDateTime getAcquiredAt();
+}

--- a/src/main/java/com/daengddang/daengdong_map/service/BlockService.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/BlockService.java
@@ -2,10 +2,10 @@ package com.daengddang.daengdong_map.service;
 
 import com.daengddang.daengdong_map.common.ErrorCode;
 import com.daengddang.daengdong_map.common.exception.BaseException;
-import com.daengddang.daengdong_map.domain.block.BlockOwnership;
 import com.daengddang.daengdong_map.dto.response.block.NearbyBlockListResponse;
 import com.daengddang.daengdong_map.dto.response.block.NearbyBlockResponse;
 import com.daengddang.daengdong_map.repository.BlockOwnershipRepository;
+import com.daengddang.daengdong_map.repository.projection.BlockOwnershipView;
 import com.daengddang.daengdong_map.util.BlockIdUtil;
 import com.daengddang.daengdong_map.util.BlockOwnershipMapper;
 import com.daengddang.daengdong_map.util.CoordinateValidator;
@@ -51,7 +51,7 @@ public class BlockService {
         return (int) Math.ceil(radiusMeters / BLOCK_METERS);
     }
 
-    private NearbyBlockResponse toNearbyBlock(BlockOwnership ownership) {
+    private NearbyBlockResponse toNearbyBlock(BlockOwnershipView ownership) {
         String blockId = BlockOwnershipMapper.toBlockId(ownership);
         return NearbyBlockResponse.from(
                 blockId,

--- a/src/main/java/com/daengddang/daengdong_map/service/BlockSyncService.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/BlockSyncService.java
@@ -6,6 +6,7 @@ import com.daengddang.daengdong_map.dto.websocket.common.WebSocketMessage;
 import com.daengddang.daengdong_map.dto.websocket.outbound.BlockSyncEntry;
 import com.daengddang.daengdong_map.dto.websocket.outbound.BlocksSyncPayload;
 import com.daengddang.daengdong_map.repository.BlockOwnershipRepository;
+import com.daengddang.daengdong_map.repository.projection.BlockOwnershipView;
 import com.daengddang.daengdong_map.websocket.WebSocketDestinations;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -65,10 +66,7 @@ public class BlockSyncService {
         List<BlockSyncEntry> entries = blockOwnershipRepository.findAllByBlockRange(
                         range.minX, range.maxX, range.minY, range.maxY
                 ).stream()
-                .map(ownership -> BlockSyncEntry.from(
-                        BlockIdUtil.toBlockId(ownership.getBlock().getX(), ownership.getBlock().getY()),
-                        ownership.getDog().getId()
-                ))
+                .map(this::toBlockSyncEntry)
                 .toList();
 
         BlocksSyncPayload payload = BlocksSyncPayload.from(entries);
@@ -85,6 +83,13 @@ public class BlockSyncService {
         int minX = areaX * AREA_SIZE;
         int minY = areaY * AREA_SIZE;
         return new AreaRange(minX, minX + AREA_SIZE - 1, minY, minY + AREA_SIZE - 1);
+    }
+
+    private BlockSyncEntry toBlockSyncEntry(BlockOwnershipView ownership) {
+        return BlockSyncEntry.from(
+                BlockIdUtil.toBlockId(ownership.getBlockX(), ownership.getBlockY()),
+                ownership.getDogId()
+        );
     }
 
     private static class AreaRange {

--- a/src/main/java/com/daengddang/daengdong_map/service/WalkService.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/WalkService.java
@@ -2,7 +2,6 @@ package com.daengddang.daengdong_map.service;
 
 import com.daengddang.daengdong_map.common.ErrorCode;
 import com.daengddang.daengdong_map.common.exception.BaseException;
-import com.daengddang.daengdong_map.domain.block.BlockOwnership;
 import com.daengddang.daengdong_map.domain.dog.Dog;
 import com.daengddang.daengdong_map.domain.walk.Walk;
 import com.daengddang.daengdong_map.domain.walk.WalkPoint;
@@ -14,6 +13,7 @@ import com.daengddang.daengdong_map.dto.response.walk.OccupiedBlockResponse;
 import com.daengddang.daengdong_map.dto.response.walk.WalkEndResponse;
 import com.daengddang.daengdong_map.dto.response.walk.WalkStartResponse;
 import com.daengddang.daengdong_map.repository.BlockOwnershipRepository;
+import com.daengddang.daengdong_map.repository.projection.BlockOwnershipView;
 import com.daengddang.daengdong_map.repository.WalkBlockLogRepository;
 import com.daengddang.daengdong_map.util.AccessValidator;
 import com.daengddang.daengdong_map.util.BlockOwnershipMapper;
@@ -132,7 +132,7 @@ public class WalkService {
         return OccupiedBlockListResponse.from(blocks);
     }
 
-    private OccupiedBlockResponse toOccupiedBlock(BlockOwnership ownership) {
+    private OccupiedBlockResponse toOccupiedBlock(BlockOwnershipView ownership) {
         String blockId = BlockOwnershipMapper.toBlockId(ownership);
         return OccupiedBlockResponse.from(
                 blockId,

--- a/src/main/java/com/daengddang/daengdong_map/util/BlockOwnershipMapper.java
+++ b/src/main/java/com/daengddang/daengdong_map/util/BlockOwnershipMapper.java
@@ -1,7 +1,6 @@
 package com.daengddang.daengdong_map.util;
 
-import com.daengddang.daengdong_map.domain.block.Block;
-import com.daengddang.daengdong_map.domain.block.BlockOwnership;
+import com.daengddang.daengdong_map.repository.projection.BlockOwnershipView;
 import java.time.LocalDateTime;
 
 public final class BlockOwnershipMapper {
@@ -9,16 +8,15 @@ public final class BlockOwnershipMapper {
     private BlockOwnershipMapper() {
     }
 
-    public static String toBlockId(BlockOwnership ownership) {
-        Block block = ownership.getBlock();
-        return BlockIdUtil.toBlockId(block.getX(), block.getY());
+    public static String toBlockId(BlockOwnershipView ownership) {
+        return BlockIdUtil.toBlockId(ownership.getBlockX(), ownership.getBlockY());
     }
 
-    public static Long toOwnerDogId(BlockOwnership ownership) {
-        return ownership.getDog().getId();
+    public static Long toOwnerDogId(BlockOwnershipView ownership) {
+        return ownership.getDogId();
     }
 
-    public static LocalDateTime toAcquiredAt(BlockOwnership ownership) {
+    public static LocalDateTime toAcquiredAt(BlockOwnershipView ownership) {
         return ownership.getAcquiredAt();
     }
 }


### PR DESCRIPTION
  ## #️⃣연관된 이슈

  > #106 #107 

  ## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- block_ownership 범위 조회/내 점유 조회를 projection 기반으로 변경
 - 엔티티 fetch join 대신 필요한 컬럼(block 좌표, dogId, acquiredAt)만 조회하도록 최적화
 - BlockService/BlockSyncService/WalkService가 projection 기반 매핑을 사용하도록 수정

  ### 스크린샷 (선택)

  ## 💬리뷰 요구사항(선택)

  > 없음
