### PR TITLE
fix: 랭킹 배치 메서드 분리(delete / insert)

### DIFF
--- a/src/main/java/com/daengddang/daengdong_map/service/ranking/batch/RankingBatchScheduler.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/ranking/batch/RankingBatchScheduler.java
@@ -14,9 +14,15 @@ public class RankingBatchScheduler {
 
     private final RankingBatchService rankingBatchService;
 
-    @Scheduled(cron = "${ranking.batch.cron:0 0 3 * * *}", zone = "${ranking.batch.zone:Asia/Seoul}")
-    public void run() {
-        log.debug("Trigger ranking batch scheduler");
-        rankingBatchService.runAll();
+    @Scheduled(cron = "${ranking.batch.cron:0 0 0 * * *}", zone = "${ranking.batch.zone:Asia/Seoul}")
+    public void runUpsert() {
+        log.debug("Trigger ranking upsert batch scheduler");
+        rankingBatchService.runUpsertAll();
+    }
+
+    @Scheduled(cron = "${ranking.batch.cleanup-cron:0 30 3 * * *}", zone = "${ranking.batch.zone:Asia/Seoul}")
+    public void runCleanup() {
+        log.debug("Trigger ranking cleanup batch scheduler");
+        rankingBatchService.runCleanupAll();
     }
 }

--- a/src/main/java/com/daengddang/daengdong_map/service/ranking/batch/RankingBatchService.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/ranking/batch/RankingBatchService.java
@@ -22,72 +22,126 @@ public class RankingBatchService {
     private final RegionRankBatchRepository regionRankBatchRepository;
     private final RegionDogRankBatchRepository regionDogRankBatchRepository;
 
-    public void runAll() {
-        log.info("Ranking batch started");
+    public void runUpsertAll() {
+        log.info("Ranking upsert batch started");
 
         for (RankingPeriodType periodType : RankingPeriodType.values()) {
-            runByPeriodType(periodType);
+            runUpsertByPeriodType(periodType);
         }
 
-        log.info("Ranking batch finished");
+        log.info("Ranking upsert batch finished");
     }
 
-    private void runByPeriodType(RankingPeriodType periodType) {
+    public void runCleanupAll() {
+        log.info("Ranking cleanup batch started");
+
+        for (RankingPeriodType periodType : RankingPeriodType.values()) {
+            runCleanupByPeriodType(periodType);
+        }
+
+        log.info("Ranking cleanup batch finished");
+    }
+
+    private void runUpsertByPeriodType(RankingPeriodType periodType) {
         String periodValue = rankingPeriodResolver.resolveCurrentPeriodValue(periodType);
-        log.info("Ranking batch period start. periodType={}, periodValue={}", periodType, periodValue);
+        log.info("Ranking upsert period start. periodType={}, periodValue={}", periodType, periodValue);
 
-        runDogGlobalRanking(periodType, periodValue);
-        runDogRegionRanking(periodType, periodValue);
-        runRegionRanking(periodType, periodValue);
-        runRegionContributionRanking(periodType, periodValue);
+        runDogGlobalRankingUpsert(periodType, periodValue);
+        runDogRegionRankingUpsert(periodType, periodValue);
+        runRegionRankingUpsert(periodType, periodValue);
+        runRegionContributionRankingUpsert(periodType, periodValue);
 
-        log.info("Ranking batch period finished. periodType={}, periodValue={}", periodType, periodValue);
+        log.info("Ranking upsert period finished. periodType={}, periodValue={}", periodType, periodValue);
     }
 
-    private void runDogGlobalRanking(RankingPeriodType periodType, String periodValue) {
+    private void runCleanupByPeriodType(RankingPeriodType periodType) {
+        String periodValue = rankingPeriodResolver.resolveCurrentPeriodValue(periodType);
+        log.info("Ranking cleanup period start. periodType={}, periodValue={}", periodType, periodValue);
+
+        runDogGlobalRankingCleanup(periodType, periodValue);
+        runDogRegionRankingCleanup(periodType, periodValue);
+        runRegionRankingCleanup(periodType, periodValue);
+        runRegionContributionRankingCleanup(periodType, periodValue);
+
+        log.info("Ranking cleanup period finished. periodType={}, periodValue={}", periodType, periodValue);
+    }
+
+    private void runDogGlobalRankingUpsert(RankingPeriodType periodType, String periodValue) {
         int upserted = dogGlobalRankBatchRepository.upsertRanks(periodType, periodValue);
+        log.info(
+                "Dog global ranking upsert completed. periodType={}, periodValue={}, upserted={}",
+                periodType,
+                periodValue,
+                upserted
+        );
+    }
+
+    private void runDogGlobalRankingCleanup(RankingPeriodType periodType, String periodValue) {
         int deleted = dogGlobalRankBatchRepository.deleteObsoleteRanks(periodType, periodValue);
         log.info(
-                "Dog global ranking batch completed. periodType={}, periodValue={}, upserted={}, deleted={}",
+                "Dog global ranking cleanup completed. periodType={}, periodValue={}, deleted={}",
                 periodType,
                 periodValue,
-                upserted,
                 deleted
         );
     }
 
-    private void runDogRegionRanking(RankingPeriodType periodType, String periodValue) {
+    private void runDogRegionRankingUpsert(RankingPeriodType periodType, String periodValue) {
         int upserted = dogRankBatchRepository.upsertRanks(periodType, periodValue);
+        log.info(
+                "Dog region ranking upsert completed. periodType={}, periodValue={}, upserted={}",
+                periodType,
+                periodValue,
+                upserted
+        );
+    }
+
+    private void runDogRegionRankingCleanup(RankingPeriodType periodType, String periodValue) {
         int deleted = dogRankBatchRepository.deleteObsoleteRanks(periodType, periodValue);
         log.info(
-                "Dog region ranking batch completed. periodType={}, periodValue={}, upserted={}, deleted={}",
+                "Dog region ranking cleanup completed. periodType={}, periodValue={}, deleted={}",
                 periodType,
                 periodValue,
-                upserted,
                 deleted
         );
     }
 
-    private void runRegionRanking(RankingPeriodType periodType, String periodValue) {
+    private void runRegionRankingUpsert(RankingPeriodType periodType, String periodValue) {
         int upserted = regionRankBatchRepository.upsertRanks(periodType, periodValue);
+        log.info(
+                "Region ranking upsert completed. periodType={}, periodValue={}, upserted={}",
+                periodType,
+                periodValue,
+                upserted
+        );
+    }
+
+    private void runRegionRankingCleanup(RankingPeriodType periodType, String periodValue) {
         int deleted = regionRankBatchRepository.deleteObsoleteRanks(periodType, periodValue);
         log.info(
-                "Region ranking batch completed. periodType={}, periodValue={}, upserted={}, deleted={}",
+                "Region ranking cleanup completed. periodType={}, periodValue={}, deleted={}",
                 periodType,
                 periodValue,
-                upserted,
                 deleted
         );
     }
 
-    private void runRegionContributionRanking(RankingPeriodType periodType, String periodValue) {
+    private void runRegionContributionRankingUpsert(RankingPeriodType periodType, String periodValue) {
         int upserted = regionDogRankBatchRepository.upsertRanks(periodType, periodValue);
-        int deleted = regionDogRankBatchRepository.deleteObsoleteRanks(periodType, periodValue);
         log.info(
-                "Region contribution ranking batch completed. periodType={}, periodValue={}, upserted={}, deleted={}",
+                "Region contribution ranking upsert completed. periodType={}, periodValue={}, upserted={}",
                 periodType,
                 periodValue,
-                upserted,
+                upserted
+        );
+    }
+
+    private void runRegionContributionRankingCleanup(RankingPeriodType periodType, String periodValue) {
+        int deleted = regionDogRankBatchRepository.deleteObsoleteRanks(periodType, periodValue);
+        log.info(
+                "Region contribution ranking cleanup completed. periodType={}, periodValue={}, deleted={}",
+                periodType,
+                periodValue,
                 deleted
         );
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -63,4 +63,5 @@ ranking:
   batch:
     enabled: true
     cron: "0 0 0 * * *"
+    cleanup-cron: "0 30 3 * * *"
     zone: Asia/Seoul


### PR DESCRIPTION
## #️⃣연관된 이슈

> #130 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- Batch Insert / Delete를 분리해 쿼리수 감소 및 유지보수성 향상

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
