### PR TITLE
feat: fast api 요청 응답 비동기 적용 event listenr 적용 / 비동기 서비스 구현

### DIFF
--- a/src/main/java/com/daengddang/daengdong_map/config/AnalysisAsyncConfig.java
+++ b/src/main/java/com/daengddang/daengdong_map/config/AnalysisAsyncConfig.java
@@ -1,0 +1,29 @@
+package com.daengddang.daengdong_map.config;
+
+import java.util.concurrent.ThreadPoolExecutor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AnalysisAsyncConfig {
+
+    @Bean(name = "analysisExecutor")
+    public ThreadPoolTaskExecutor analysisExecutor(
+            @Value("${analysis.async.executor.core-pool-size:4}") int corePoolSize,
+            @Value("${analysis.async.executor.max-pool-size:8}") int maxPoolSize,
+            @Value("${analysis.async.executor.queue-capacity:200}") int queueCapacity
+    ) {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(corePoolSize);
+        executor.setMaxPoolSize(maxPoolSize);
+        executor.setQueueCapacity(queueCapacity);
+        executor.setThreadNamePrefix("analysis-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/daengddang/daengdong_map/controller/AnalysisTaskController.java
+++ b/src/main/java/com/daengddang/daengdong_map/controller/AnalysisTaskController.java
@@ -28,7 +28,7 @@ public class AnalysisTaskController implements AnalysisTaskApi {
 
     private final ExternalAnalysisTaskService externalAnalysisTaskService;
 
-    @PostMapping("/walks/{walkId}/missions/analysis-tasks")
+    @PostMapping("/walks/{walkId}/missions/analysis/tasks")
     @ResponseStatus(HttpStatus.ACCEPTED)
     @Override
     public ApiResponse<AnalysisTaskAcceptedResponse> createMissionTask(
@@ -40,7 +40,7 @@ public class AnalysisTaskController implements AnalysisTaskApi {
         return ApiResponse.success(SuccessCode.ANALYSIS_TASK_ACCEPTED, response);
     }
 
-    @PostMapping("/walks/{walkId}/expressions/analysis-tasks")
+    @PostMapping("/walks/{walkId}/expressions/analysis/tasks")
     @ResponseStatus(HttpStatus.ACCEPTED)
     @Override
     public ApiResponse<AnalysisTaskAcceptedResponse> createExpressionTask(
@@ -53,7 +53,7 @@ public class AnalysisTaskController implements AnalysisTaskApi {
         return ApiResponse.success(SuccessCode.ANALYSIS_TASK_ACCEPTED, response);
     }
 
-    @PostMapping("/healthcares/analysis-tasks")
+    @PostMapping("/healthcares/analysis/tasks")
     @ResponseStatus(HttpStatus.ACCEPTED)
     @Override
     public ApiResponse<AnalysisTaskAcceptedResponse> createHealthcareTask(
@@ -65,7 +65,7 @@ public class AnalysisTaskController implements AnalysisTaskApi {
         return ApiResponse.success(SuccessCode.ANALYSIS_TASK_ACCEPTED, response);
     }
 
-    @GetMapping("/walks/{walkId}/analysis-tasks/{taskId}")
+    @GetMapping("/walks/{walkId}/analysis/tasks/{taskId}")
     @Override
     public ApiResponse<AnalysisTaskDetailResponse> getTask(
             @AuthenticationPrincipal AuthUser authUser,
@@ -77,7 +77,7 @@ public class AnalysisTaskController implements AnalysisTaskApi {
         return ApiResponse.success(SuccessCode.ANALYSIS_TASK_RETRIEVED, response);
     }
 
-    @GetMapping("/healthcares/analysis-tasks/{taskId}")
+    @GetMapping("/healthcares/analysis/tasks/{taskId}")
     @Override
     public ApiResponse<AnalysisTaskDetailResponse> getHealthcareTask(
             @AuthenticationPrincipal AuthUser authUser,

--- a/src/main/java/com/daengddang/daengdong_map/domain/task/ExternalAnalysisTask.java
+++ b/src/main/java/com/daengddang/daengdong_map/domain/task/ExternalAnalysisTask.java
@@ -78,6 +78,12 @@ public class ExternalAnalysisTask {
     @Column(name = "video_url", length = 1000)
     private String videoUrl;
 
+    @Column(name = "result_type", length = 30)
+    private String resultType;
+
+    @Column(name = "result_id", length = 64)
+    private String resultId;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "walk_id")
     private Walk walk;
@@ -96,6 +102,8 @@ public class ExternalAnalysisTask {
                                  String errorCode,
                                  String errorMessage,
                                  String videoUrl,
+                                 String resultType,
+                                 String resultId,
                                  Walk walk,
                                  Dog dog) {
         this.taskId = taskId;
@@ -107,6 +115,8 @@ public class ExternalAnalysisTask {
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
         this.videoUrl = videoUrl;
+        this.resultType = resultType;
+        this.resultId = resultId;
         this.walk = walk;
         this.dog = dog;
     }

--- a/src/main/java/com/daengddang/daengdong_map/dto/request/expression/ExpressionAnalyzeRequest.java
+++ b/src/main/java/com/daengddang/daengdong_map/dto/request/expression/ExpressionAnalyzeRequest.java
@@ -1,11 +1,22 @@
 package com.daengddang.daengdong_map.dto.request.expression;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ExpressionAnalyzeRequest {
 
     @NotBlank
     private String videoUrl;
+
+    private ExpressionAnalyzeRequest(String videoUrl) {
+        this.videoUrl = videoUrl;
+    }
+
+    public static ExpressionAnalyzeRequest of(String videoUrl) {
+        return new ExpressionAnalyzeRequest(videoUrl);
+    }
 }

--- a/src/main/java/com/daengddang/daengdong_map/dto/request/healthcare/HealthcareAnalyzeRequest.java
+++ b/src/main/java/com/daengddang/daengdong_map/dto/request/healthcare/HealthcareAnalyzeRequest.java
@@ -1,11 +1,22 @@
 package com.daengddang.daengdong_map.dto.request.healthcare;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class HealthcareAnalyzeRequest {
 
     @NotBlank
     private String videoUrl;
+
+    private HealthcareAnalyzeRequest(String videoUrl) {
+        this.videoUrl = videoUrl;
+    }
+
+    public static HealthcareAnalyzeRequest of(String videoUrl) {
+        return new HealthcareAnalyzeRequest(videoUrl);
+    }
 }

--- a/src/main/java/com/daengddang/daengdong_map/dto/response/task/AnalysisTaskDetailResponse.java
+++ b/src/main/java/com/daengddang/daengdong_map/dto/response/task/AnalysisTaskDetailResponse.java
@@ -17,6 +17,8 @@ public class AnalysisTaskDetailResponse {
     private final LocalDateTime finishedAt;
     private final String errorCode;
     private final String errorMessage;
+    private final String resultType;
+    private final String resultId;
 
     @Builder
     private AnalysisTaskDetailResponse(String taskId,
@@ -27,7 +29,9 @@ public class AnalysisTaskDetailResponse {
                                        LocalDateTime startedAt,
                                        LocalDateTime finishedAt,
                                        String errorCode,
-                                       String errorMessage) {
+                                       String errorMessage,
+                                       String resultType,
+                                       String resultId) {
         this.taskId = taskId;
         this.walkId = walkId;
         this.type = type;
@@ -37,6 +41,8 @@ public class AnalysisTaskDetailResponse {
         this.finishedAt = finishedAt;
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
+        this.resultType = resultType;
+        this.resultId = resultId;
     }
 
     public static AnalysisTaskDetailResponse from(ExternalAnalysisTask task) {
@@ -50,6 +56,8 @@ public class AnalysisTaskDetailResponse {
                 .finishedAt(task.getFinishedAt())
                 .errorCode(task.getErrorCode())
                 .errorMessage(task.getErrorMessage())
+                .resultType(task.getResultType())
+                .resultId(task.getResultId())
                 .build();
     }
 }

--- a/src/main/java/com/daengddang/daengdong_map/event/ExternalAnalysisTaskCreatedEvent.java
+++ b/src/main/java/com/daengddang/daengdong_map/event/ExternalAnalysisTaskCreatedEvent.java
@@ -1,0 +1,16 @@
+package com.daengddang.daengdong_map.event;
+
+import com.daengddang.daengdong_map.domain.task.ExternalAnalysisTaskType;
+import lombok.Getter;
+
+@Getter
+public class ExternalAnalysisTaskCreatedEvent {
+
+    private final String taskId;
+    private final ExternalAnalysisTaskType type;
+
+    public ExternalAnalysisTaskCreatedEvent(String taskId, ExternalAnalysisTaskType type) {
+        this.taskId = taskId;
+        this.type = type;
+    }
+}

--- a/src/main/java/com/daengddang/daengdong_map/event/listener/ExternalAnalysisTaskEventListener.java
+++ b/src/main/java/com/daengddang/daengdong_map/event/listener/ExternalAnalysisTaskEventListener.java
@@ -1,0 +1,26 @@
+package com.daengddang.daengdong_map.event.listener;
+
+import com.daengddang.daengdong_map.event.ExternalAnalysisTaskCreatedEvent;
+import com.daengddang.daengdong_map.service.ExternalAnalysisTaskProcessor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExternalAnalysisTaskEventListener {
+
+    private final ExternalAnalysisTaskProcessor externalAnalysisTaskProcessor;
+
+    @Async("analysisExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onCreated(ExternalAnalysisTaskCreatedEvent event) {
+        log.info("외부 분석 작업 생성 이벤트 수신(커밋 이후, 비동기 처리 시작). taskId={}, type={}",
+                event.getTaskId(), event.getType());
+        externalAnalysisTaskProcessor.process(event.getTaskId());
+    }
+}

--- a/src/main/java/com/daengddang/daengdong_map/ratelimit/RateLimitPolicy.java
+++ b/src/main/java/com/daengddang/daengdong_map/ratelimit/RateLimitPolicy.java
@@ -18,21 +18,21 @@ public class RateLimitPolicy {
                 rule("WALKS_DIARY", "POST", "/api/v3/walks/{walkId}/diaries", 6, 60),
 
                 rule("MISSIONS_ANALYSIS", "POST", "/api/v3/walks/{walkId}/missions/analysis", 5, 60),
-                rule("MISSIONS_ANALYSIS_TASKS", "POST", "/api/v3/walks/{walkId}/missions/analysis-tasks", 5, 60),
+                rule("MISSIONS_ANALYSIS_TASKS", "POST", "/api/v3/walks/{walkId}/missions/analysis/tasks", 5, 60),
                 rule("MISSIONS_UPLOAD", "POST", "/api/v3/walks/{walkId}/missions", 30, 60),
                 rule("MISSIONS_LIST", "GET", "/api/v3/walks/{walkId}/missions", 60, 60),
 
                 rule("EXPRESSIONS_ANALYSIS", "POST",
                         "/api/v3/walks/{walkId}/expressions/analysis", 10, 60),
                 rule("EXPRESSIONS_ANALYSIS_TASKS", "POST",
-                        "/api/v3/walks/{walkId}/expressions/analysis-tasks", 10, 60),
+                        "/api/v3/walks/{walkId}/expressions/analysis/tasks", 10, 60),
 
                 rule("HEALTHCARE_ANALYSIS_TASKS", "POST",
-                        "/api/v3/healthcares/analysis-tasks", 10, 60),
+                        "/api/v3/healthcares/analysis/tasks", 10, 60),
                 rule("ANALYSIS_TASKS_GET", "GET",
-                        "/api/v3/walks/{walkId}/analysis-tasks/{taskId}", 60, 60),
+                        "/api/v3/walks/{walkId}/analysis/tasks/{taskId}", 60, 60),
                 rule("HEALTHCARE_ANALYSIS_TASKS_GET", "GET",
-                        "/api/v3/healthcares/analysis-tasks/{taskId}", 60, 60),
+                        "/api/v3/healthcares/analysis/tasks/{taskId}", 60, 60),
 
                 rule("PRESIGNED_URL", "POST", "/api/v3/presigned-url", 30, 60),
 

--- a/src/main/java/com/daengddang/daengdong_map/repository/ExternalAnalysisTaskRepository.java
+++ b/src/main/java/com/daengddang/daengdong_map/repository/ExternalAnalysisTaskRepository.java
@@ -5,6 +5,11 @@ import com.daengddang.daengdong_map.domain.task.ExternalAnalysisTaskStatus;
 import com.daengddang.daengdong_map.domain.task.ExternalAnalysisTaskType;
 import java.util.List;
 import java.util.Optional;
+import java.time.LocalDateTime;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,6 +17,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ExternalAnalysisTaskRepository extends JpaRepository<ExternalAnalysisTask, Long> {
 
     Optional<ExternalAnalysisTask> findByTaskId(String taskId);
+
+    @EntityGraph(attributePaths = {"walk", "dog", "dog.user"})
+    Optional<ExternalAnalysisTask> findWithContextByTaskId(String taskId);
 
     Optional<ExternalAnalysisTask> findByWalkIdAndTaskId(Long walkId, String taskId);
 
@@ -65,4 +73,59 @@ public interface ExternalAnalysisTaskRepository extends JpaRepository<ExternalAn
                 PageRequest.of(0, batchSize)
         );
     }
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update ExternalAnalysisTask task
+               set task.status = :running,
+                   task.startedAt = :startedAt,
+                   task.errorCode = null,
+                   task.errorMessage = null
+             where task.taskId = :taskId
+               and task.status = :pending
+            """)
+    int markRunningIfPending(
+            @Param("taskId") String taskId,
+            @Param("pending") ExternalAnalysisTaskStatus pending,
+            @Param("running") ExternalAnalysisTaskStatus running,
+            @Param("startedAt") LocalDateTime startedAt
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update ExternalAnalysisTask task
+               set task.status = :success,
+                   task.finishedAt = :finishedAt,
+                   task.resultType = :resultType,
+                   task.resultId = :resultId
+             where task.taskId = :taskId
+               and task.status = :running
+            """)
+    int markSuccessIfRunning(
+            @Param("taskId") String taskId,
+            @Param("running") ExternalAnalysisTaskStatus running,
+            @Param("success") ExternalAnalysisTaskStatus success,
+            @Param("finishedAt") LocalDateTime finishedAt,
+            @Param("resultType") String resultType,
+            @Param("resultId") String resultId
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update ExternalAnalysisTask task
+               set task.status = :fail,
+                   task.finishedAt = :finishedAt,
+                   task.errorCode = :errorCode,
+                   task.errorMessage = :errorMessage
+             where task.taskId = :taskId
+               and task.status in :statuses
+            """)
+    int markFail(
+            @Param("taskId") String taskId,
+            @Param("statuses") List<ExternalAnalysisTaskStatus> statuses,
+            @Param("fail") ExternalAnalysisTaskStatus fail,
+            @Param("finishedAt") LocalDateTime finishedAt,
+            @Param("errorCode") String errorCode,
+            @Param("errorMessage") String errorMessage
+    );
 }

--- a/src/main/java/com/daengddang/daengdong_map/service/ExternalAnalysisTaskProcessor.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/ExternalAnalysisTaskProcessor.java
@@ -1,0 +1,104 @@
+package com.daengddang.daengdong_map.service;
+
+import com.daengddang.daengdong_map.common.ErrorCode;
+import com.daengddang.daengdong_map.common.exception.BaseException;
+import com.daengddang.daengdong_map.domain.task.ExternalAnalysisTask;
+import com.daengddang.daengdong_map.domain.task.ExternalAnalysisTaskType;
+import com.daengddang.daengdong_map.dto.request.expression.ExpressionAnalyzeRequest;
+import com.daengddang.daengdong_map.dto.request.healthcare.HealthcareAnalyzeRequest;
+import com.daengddang.daengdong_map.dto.response.healthcare.HealthcareAnalyzeResponse;
+import com.daengddang.daengdong_map.repository.ExternalAnalysisTaskRepository;
+import com.daengddang.daengdong_map.repository.ExpressionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ExternalAnalysisTaskProcessor {
+
+    private final ExternalAnalysisTaskRepository externalAnalysisTaskRepository;
+    private final ExternalAnalysisTaskStateService externalAnalysisTaskStateService;
+    private final MissionJudgeService missionJudgeService;
+    private final ExpressionAnalyzeService expressionAnalyzeService;
+    private final HealthcareService healthcareService;
+    private final ExpressionRepository expressionRepository;
+
+    public void process(String taskId) {
+        ExternalAnalysisTask task = externalAnalysisTaskRepository.findWithContextByTaskId(taskId)
+                .orElse(null);
+        if (task == null) {
+            log.warn("외부 분석 작업을 찾을 수 없습니다. taskId={}", taskId);
+            return;
+        }
+
+        if (!externalAnalysisTaskStateService.markRunningIfPending(taskId)) {
+            log.info("외부 분석 작업 상태 전이 생략(이미 처리 중/완료). taskId={}", taskId);
+            return;
+        }
+
+        try {
+            TaskResultRef resultRef = execute(task);
+            externalAnalysisTaskStateService.markSuccessIfRunning(taskId, resultRef.resultType(), resultRef.resultId());
+            log.info("외부 분석 작업 처리 성공. taskId={}, type={}", taskId, task.getType());
+        } catch (BaseException ex) {
+            String code = ex.getErrorCode().name();
+            externalAnalysisTaskStateService.markFail(taskId, code, ex.getMessage());
+            log.warn("외부 분석 작업 처리 실패. taskId={}, type={}, errorCode={}",
+                    taskId, task.getType(), code);
+        } catch (Exception ex) {
+            externalAnalysisTaskStateService.markFail(taskId, ErrorCode.INTERNAL_SERVER_ERROR.name(), ex.getMessage());
+            log.error("외부 분석 작업 처리 중 예외. taskId={}, type={}", taskId, task.getType(), ex);
+        }
+    }
+
+    private TaskResultRef execute(ExternalAnalysisTask task) {
+        Long userId = task.getDog().getUser().getId();
+        ExternalAnalysisTaskType type = task.getType();
+        Long walkId = task.getWalk() == null ? null : task.getWalk().getId();
+
+        switch (type) {
+            case MISSION -> {
+                missionJudgeService.judge(userId, requireWalkId(task));
+                return new TaskResultRef("MISSION", String.valueOf(walkId));
+            }
+            case EXPRESSION -> {
+                expressionAnalyzeService.analyze(
+                        userId,
+                        requireWalkId(task),
+                        ExpressionAnalyzeRequest.of(requireVideoUrl(task))
+                );
+                Long expressionId = expressionRepository.findByWalk(task.getWalk())
+                        .map(expression -> expression.getId())
+                        .orElseThrow(() -> new BaseException(ErrorCode.RESOURCE_NOT_FOUND));
+                return new TaskResultRef("EXPRESSION", String.valueOf(expressionId));
+            }
+            case HEALTHCARE -> {
+                HealthcareAnalyzeResponse response = healthcareService.analyze(
+                        userId,
+                        HealthcareAnalyzeRequest.of(requireVideoUrl(task))
+                );
+                return new TaskResultRef("HEALTHCARE", String.valueOf(response.getHealthcareId()));
+            }
+        }
+        throw new BaseException(ErrorCode.INVALID_FORMAT);
+    }
+
+    private Long requireWalkId(ExternalAnalysisTask task) {
+        if (task.getWalk() == null || task.getWalk().getId() == null) {
+            throw new BaseException(ErrorCode.INVALID_FORMAT);
+        }
+        return task.getWalk().getId();
+    }
+
+    private String requireVideoUrl(ExternalAnalysisTask task) {
+        if (task.getVideoUrl() == null || task.getVideoUrl().isBlank()) {
+            throw new BaseException(ErrorCode.INVALID_FORMAT);
+        }
+        return task.getVideoUrl();
+    }
+
+    private record TaskResultRef(String resultType, String resultId) {
+    }
+}

--- a/src/main/java/com/daengddang/daengdong_map/service/ExternalAnalysisTaskService.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/ExternalAnalysisTaskService.java
@@ -12,12 +12,14 @@ import com.daengddang.daengdong_map.dto.request.expression.ExpressionAnalyzeRequ
 import com.daengddang.daengdong_map.dto.request.healthcare.HealthcareAnalyzeRequest;
 import com.daengddang.daengdong_map.dto.response.task.AnalysisTaskAcceptedResponse;
 import com.daengddang.daengdong_map.dto.response.task.AnalysisTaskDetailResponse;
+import com.daengddang.daengdong_map.event.ExternalAnalysisTaskCreatedEvent;
 import com.daengddang.daengdong_map.repository.ExternalAnalysisTaskRepository;
 import com.daengddang.daengdong_map.repository.MissionUploadRepository;
 import com.daengddang.daengdong_map.util.AccessValidator;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +30,7 @@ public class ExternalAnalysisTaskService {
     private final AccessValidator accessValidator;
     private final MissionUploadRepository missionUploadRepository;
     private final ExternalAnalysisTaskRepository externalAnalysisTaskRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public AnalysisTaskAcceptedResponse createMissionTask(Long userId, Long walkId) {
@@ -91,6 +94,7 @@ public class ExternalAnalysisTaskService {
                             .dog(walk.getDog())
                             .build()
             );
+            eventPublisher.publishEvent(new ExternalAnalysisTaskCreatedEvent(saved.getTaskId(), saved.getType()));
             return AnalysisTaskAcceptedResponse.from(saved);
         } catch (DataIntegrityViolationException ex) {
             ExternalAnalysisTask existing = externalAnalysisTaskRepository
@@ -115,6 +119,7 @@ public class ExternalAnalysisTaskService {
                             .dog(dog)
                             .build()
             );
+            eventPublisher.publishEvent(new ExternalAnalysisTaskCreatedEvent(saved.getTaskId(), saved.getType()));
             return AnalysisTaskAcceptedResponse.from(saved);
         } catch (DataIntegrityViolationException ex) {
             ExternalAnalysisTask existing = externalAnalysisTaskRepository

--- a/src/main/java/com/daengddang/daengdong_map/service/ExternalAnalysisTaskStateService.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/ExternalAnalysisTaskStateService.java
@@ -1,0 +1,52 @@
+package com.daengddang.daengdong_map.service;
+
+import com.daengddang.daengdong_map.domain.task.ExternalAnalysisTaskStatus;
+import com.daengddang.daengdong_map.repository.ExternalAnalysisTaskRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ExternalAnalysisTaskStateService {
+
+    private final ExternalAnalysisTaskRepository externalAnalysisTaskRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public boolean markRunningIfPending(String taskId) {
+        int updated = externalAnalysisTaskRepository.markRunningIfPending(
+                taskId,
+                ExternalAnalysisTaskStatus.PENDING,
+                ExternalAnalysisTaskStatus.RUNNING,
+                LocalDateTime.now()
+        );
+        return updated > 0;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markSuccessIfRunning(String taskId, String resultType, String resultId) {
+        externalAnalysisTaskRepository.markSuccessIfRunning(
+                taskId,
+                ExternalAnalysisTaskStatus.RUNNING,
+                ExternalAnalysisTaskStatus.SUCCESS,
+                LocalDateTime.now(),
+                resultType,
+                resultId
+        );
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markFail(String taskId, String errorCode, String errorMessage) {
+        externalAnalysisTaskRepository.markFail(
+                taskId,
+                List.of(ExternalAnalysisTaskStatus.PENDING, ExternalAnalysisTaskStatus.RUNNING),
+                ExternalAnalysisTaskStatus.FAIL,
+                LocalDateTime.now(),
+                errorCode,
+                errorMessage
+        );
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -84,3 +84,10 @@ ranking:
     cron: "0 0 0 * * *"
     cleanup-cron: "0 30 3 * * *"
     zone: Asia/Seoul
+
+analysis:
+  async:
+    executor:
+      core-pool-size: ${ANALYSIS_ASYNC_CORE_POOL_SIZE:4}
+      max-pool-size: ${ANALYSIS_ASYNC_MAX_POOL_SIZE:8}
+      queue-capacity: ${ANALYSIS_ASYNC_QUEUE_CAPACITY:200}


### PR DESCRIPTION
 ## #️⃣연관된 이슈

  > #136 #140                                                                                                                               

  ## 📝작업 내용

  - 외부 분석 비동기 Task 흐름 추가
      - ExternalAnalysisTask 기반으로 task 생성/조회 API 구성
      - 생성 API: 미션/표정/헬스케어 분리
      - 조회 API: task 상태(PENDING/RUNNING/SUCCESS/FAIL) 조회
  - 이벤트 기반 처리 구조 적용
      - task 생성 시 이벤트 발행
      - @TransactionalEventListener(AFTER_COMMIT) + @Async(analysisExecutor)로 후처리
  - 실제 처리 워커 연결
      - 타입별 기존 분석 서비스 호출(MISSION/EXPRESSION/HEALTHCARE)
      - 상태 전이 및 실패 코드 저장 로직 반영

  ### 스크린샷 (선택)

  > 없음                                                                                                                                                                           

  ## 💬리뷰 요구사항(선택)
