### PR TITLE
refactor: region 조회 redis cache 추가

### DIFF
--- a/src/main/java/com/daengddang/daengdong_map/dto/response/user/RegionListResponse.java
+++ b/src/main/java/com/daengddang/daengdong_map/dto/response/user/RegionListResponse.java
@@ -19,4 +19,8 @@ public class RegionListResponse {
                 .toList();
         return new RegionListResponse(responses);
     }
+
+    public static RegionListResponse of(List<RegionResponse> regions) {
+        return new RegionListResponse(regions);
+    }
 }

--- a/src/main/java/com/daengddang/daengdong_map/dto/response/user/RegionResponse.java
+++ b/src/main/java/com/daengddang/daengdong_map/dto/response/user/RegionResponse.java
@@ -26,4 +26,8 @@ public class RegionResponse {
         Long parentId = region.getParent() == null ? null : region.getParent().getId();
         return new RegionResponse(region.getId(), region.getName(), region.getLevel(), parentId);
     }
+
+    public static RegionResponse of(Long regionId, String name, RegionLevel level, Long parentRegionId) {
+        return new RegionResponse(regionId, name, level, parentRegionId);
+    }
 }

--- a/src/main/java/com/daengddang/daengdong_map/service/RegionService.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/RegionService.java
@@ -7,7 +7,12 @@ import com.daengddang.daengdong_map.domain.region.RegionStatus;
 import com.daengddang.daengdong_map.dto.response.region.RegionResponse;
 import com.daengddang.daengdong_map.dto.response.user.RegionListResponse;
 import com.daengddang.daengdong_map.repository.RegionRepository;
+import com.daengddang.daengdong_map.service.cache.RegionCacheMetrics;
+import com.daengddang.daengdong_map.service.cache.RegionCacheStore;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,23 +20,22 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class RegionService {
 
+    private static final Long ROOT_PARENT_KEY = -1L;
+
     private final RegionRepository regionRepository;
+    private final RegionCacheStore regionCacheStore;
+    private final RegionCacheMetrics regionCacheMetrics;
+    private final ConcurrentHashMap<Long, CompletableFuture<RegionListResponse>> inFlightRegionLoads = new ConcurrentHashMap<>();
 
     public RegionListResponse getRegions(Long parentId) {
-        List<Region> regions;
-        if (parentId == null) {
-            regions = regionRepository.findByParentIsNullAndStatusOrderByNameAsc(RegionStatus.ACTIVE);
-        } else {
-            Region parent = regionRepository
+        Region parent = null;
+        if (parentId != null) {
+            parent = regionRepository
                     .findByIdAndStatus(parentId, RegionStatus.ACTIVE)
                     .orElseThrow(() -> new BaseException(ErrorCode.REGION_NOT_FOUND));
-            regions = regionRepository.findByParentAndStatusOrderByNameAsc(parent, RegionStatus.ACTIVE);
-            if (regions.isEmpty()) {
-                throw new BaseException(ErrorCode.REGION_NOT_FOUND);
-            }
         }
 
-        return RegionListResponse.from(regions);
+        return getCachedOrLoad(parentId, parent);
     }
 
     public RegionResponse getRegion(Long regionId) {
@@ -40,5 +44,55 @@ public class RegionService {
         );
 
         return RegionResponse.from(region);
+    }
+
+    private RegionListResponse getCachedOrLoad(Long parentId, Region parent) {
+        Optional<RegionListResponse> cached = regionCacheStore.get(parentId);
+        if (cached.isPresent()) {
+            RegionListResponse response = cached.get();
+            ensureNonEmptyForChild(parentId, response);
+            return response;
+        }
+
+        Long inFlightKey = parentId == null ? ROOT_PARENT_KEY : parentId;
+        while (true) {
+            CompletableFuture<RegionListResponse> existing = inFlightRegionLoads.get(inFlightKey);
+            if (existing != null) {
+                RegionListResponse response = existing.join();
+                ensureNonEmptyForChild(parentId, response);
+                return response;
+            }
+
+            CompletableFuture<RegionListResponse> created = new CompletableFuture<>();
+            if (inFlightRegionLoads.putIfAbsent(inFlightKey, created) == null) {
+                try {
+                    RegionListResponse response = loadFromDbAndCache(parentId, parent);
+                    created.complete(response);
+                    return response;
+                } catch (Exception e) {
+                    created.completeExceptionally(e);
+                    throw e;
+                } finally {
+                    inFlightRegionLoads.remove(inFlightKey, created);
+                }
+            }
+        }
+    }
+
+    private RegionListResponse loadFromDbAndCache(Long parentId, Region parent) {
+        regionCacheMetrics.recordDbLoad();
+        List<Region> regions = parentId == null
+                ? regionRepository.findByParentIsNullAndStatusOrderByNameAsc(RegionStatus.ACTIVE)
+                : regionRepository.findByParentAndStatusOrderByNameAsc(parent, RegionStatus.ACTIVE);
+        RegionListResponse response = RegionListResponse.from(regions);
+        ensureNonEmptyForChild(parentId, response);
+        regionCacheStore.put(parentId, response);
+        return response;
+    }
+
+    private void ensureNonEmptyForChild(Long parentId, RegionListResponse response) {
+        if (parentId != null && response.getRegions().isEmpty()) {
+            throw new BaseException(ErrorCode.REGION_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/com/daengddang/daengdong_map/service/cache/RegionCacheMetrics.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/cache/RegionCacheMetrics.java
@@ -1,0 +1,135 @@
+package com.daengddang.daengdong_map.service.cache;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.concurrent.atomic.LongAdder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Getter
+public class RegionCacheMetrics {
+
+    private static final long LOG_EVERY = 100L;
+
+    private final LongAdder hit = new LongAdder();
+    private final LongAdder miss = new LongAdder();
+    private final LongAdder bypassDisabled = new LongAdder();
+    private final LongAdder fallbackError = new LongAdder();
+    private final LongAdder dbLoad = new LongAdder();
+    private final LongAdder readError = new LongAdder();
+    private final LongAdder writeError = new LongAdder();
+
+    private final Counter hitCounter;
+    private final Counter missCounter;
+    private final Counter bypassDisabledCounter;
+    private final Counter fallbackErrorCounter;
+    private final Counter dbLoadCounter;
+    private final Counter readErrorCounter;
+    private final Counter writeErrorCounter;
+
+    public RegionCacheMetrics(ObjectProvider<MeterRegistry> registryProvider) {
+        MeterRegistry registry = registryProvider.getIfAvailable();
+        if (registry == null) {
+            hitCounter = null;
+            missCounter = null;
+            bypassDisabledCounter = null;
+            fallbackErrorCounter = null;
+            dbLoadCounter = null;
+            readErrorCounter = null;
+            writeErrorCounter = null;
+            return;
+        }
+
+        hitCounter = Counter.builder("cache.region.hit").description("Region cache hit count").register(registry);
+        missCounter = Counter.builder("cache.region.miss").description("Region cache miss count").register(registry);
+        bypassDisabledCounter = Counter.builder("cache.region.bypass.disabled")
+                .description("Region cache bypass count when cache is disabled")
+                .register(registry);
+        fallbackErrorCounter = Counter.builder("cache.region.fallback.error")
+                .description("Region cache fallback-to-db count due to cache error")
+                .register(registry);
+        dbLoadCounter = Counter.builder("cache.region.db.load")
+                .description("Region DB load count when cache miss/fallback occurs")
+                .register(registry);
+        readErrorCounter = Counter.builder("cache.region.read.error")
+                .description("Region cache read error count")
+                .register(registry);
+        writeErrorCounter = Counter.builder("cache.region.write.error")
+                .description("Region cache write error count")
+                .register(registry);
+    }
+
+    public void recordHit() {
+        hit.increment();
+        increment(hitCounter);
+        maybeLog();
+    }
+
+    public void recordMiss() {
+        miss.increment();
+        increment(missCounter);
+        maybeLog();
+    }
+
+    public void recordBypassDisabled() {
+        bypassDisabled.increment();
+        increment(bypassDisabledCounter);
+        maybeLog();
+    }
+
+    public void recordFallbackError() {
+        fallbackError.increment();
+        increment(fallbackErrorCounter);
+        maybeLog();
+    }
+
+    public void recordDbLoad() {
+        dbLoad.increment();
+        increment(dbLoadCounter);
+        maybeLog();
+    }
+
+    public void recordReadError() {
+        readError.increment();
+        increment(readErrorCounter);
+        maybeLog();
+    }
+
+    public void recordWriteError() {
+        writeError.increment();
+        increment(writeErrorCounter);
+        maybeLog();
+    }
+
+    private void maybeLog() {
+        long total = hit.sum() + miss.sum() + bypassDisabled.sum() + fallbackError.sum() + dbLoad.sum();
+        if (total > 0 && total % LOG_EVERY == 0) {
+            long hitCount = hit.sum();
+            long missCount = miss.sum();
+            double hitRatio = (hitCount + missCount) == 0
+                    ? 0.0
+                    : (hitCount * 100.0) / (hitCount + missCount);
+            log.info(
+                    "[RegionCacheMetrics] hit={}, miss={}, hitRatio={}%, bypassDisabled={}, fallbackError={}, dbLoad={}, readError={}, writeError={}",
+                    hitCount,
+                    missCount,
+                    String.format("%.2f", hitRatio),
+                    bypassDisabled.sum(),
+                    fallbackError.sum(),
+                    dbLoad.sum(),
+                    readError.sum(),
+                    writeError.sum()
+            );
+        }
+    }
+
+    private void increment(Counter counter) {
+        if (counter != null) {
+            counter.increment();
+        }
+    }
+}

--- a/src/main/java/com/daengddang/daengdong_map/service/cache/RegionCacheProperties.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/cache/RegionCacheProperties.java
@@ -1,0 +1,19 @@
+package com.daengddang.daengdong_map.service.cache;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "cache.region")
+public class RegionCacheProperties {
+
+    private Boolean enabled;
+    private Long ttlSeconds;
+    private Integer jitterPercent;
+    private String keyVersion;
+    private String key = "cache:regions";
+}

--- a/src/main/java/com/daengddang/daengdong_map/service/cache/RegionCacheStore.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/cache/RegionCacheStore.java
@@ -1,0 +1,163 @@
+package com.daengddang.daengdong_map.service.cache;
+
+import com.daengddang.daengdong_map.domain.region.RegionLevel;
+import com.daengddang.daengdong_map.dto.response.user.RegionListResponse;
+import com.daengddang.daengdong_map.dto.response.user.RegionResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.StringCodec;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RegionCacheStore {
+
+    private static final String ROOT_PARENT_ID = "root";
+
+    private final RedissonClient redissonClient;
+    private final ObjectMapper objectMapper;
+    private final CacheDefaultProperties defaultProperties;
+    private final RegionCacheProperties properties;
+    private final RegionCacheMetrics metrics;
+
+    public Optional<RegionListResponse> get(Long parentId) {
+        if (!isEnabled()) {
+            metrics.recordBypassDisabled();
+            return Optional.empty();
+        }
+
+        try {
+            RBucket<String> bucket = redissonClient.getBucket(resolveCacheKey(parentId), StringCodec.INSTANCE);
+            String cachedJson = bucket.get();
+            if (cachedJson == null || cachedJson.isBlank()) {
+                metrics.recordMiss();
+                return Optional.empty();
+            }
+            RegionCachePayload payload = objectMapper.readValue(cachedJson, RegionCachePayload.class);
+            RegionListResponse cached = fromPayload(payload);
+            metrics.recordHit();
+            return Optional.of(cached);
+        } catch (Exception e) {
+            metrics.recordReadError();
+            metrics.recordFallbackError();
+            log.warn("지역 캐시 조회 실패 (Region cache read failed)", e);
+            return Optional.empty();
+        }
+    }
+
+    public void put(Long parentId, RegionListResponse response) {
+        if (!isEnabled()) {
+            return;
+        }
+
+        try {
+            String responseJson = objectMapper.writeValueAsString(toPayload(response));
+            RBucket<String> bucket = redissonClient.getBucket(resolveCacheKey(parentId), StringCodec.INSTANCE);
+            bucket.setAsync(responseJson, resolveTtlSeconds(), TimeUnit.SECONDS)
+                    .whenComplete((result, throwable) -> {
+                        if (throwable != null) {
+                            metrics.recordWriteError();
+                            log.warn("지역 캐시 비동기 저장 실패 (Region cache async write failed)", throwable);
+                        }
+                    });
+        } catch (Exception e) {
+            metrics.recordWriteError();
+            log.warn("지역 캐시 저장 실패 (Region cache write failed)", e);
+        }
+    }
+
+    private long resolveTtlSeconds() {
+        long base = properties.getTtlSeconds() == null
+                ? defaultProperties.getTtlSeconds()
+                : properties.getTtlSeconds();
+        int jitterPercent = properties.getJitterPercent() == null
+                ? defaultProperties.getJitterPercent()
+                : properties.getJitterPercent();
+        jitterPercent = Math.max(0, Math.min(100, jitterPercent));
+        if (jitterPercent == 0 || base <= 0) {
+            return Math.max(1, base);
+        }
+
+        double ratio = jitterPercent / 100.0;
+        double min = base * (1 - ratio);
+        double max = base * (1 + ratio);
+        long ttl = Math.round(ThreadLocalRandom.current().nextDouble(min, max));
+        return Math.max(1, ttl);
+    }
+
+    private boolean isEnabled() {
+        return properties.getEnabled() == null
+                ? defaultProperties.isEnabled()
+                : properties.getEnabled();
+    }
+
+    private String resolveCacheKey(Long parentId) {
+        String version = properties.getKeyVersion() == null
+                ? defaultProperties.getKeyVersion()
+                : properties.getKeyVersion();
+        String parentKey = parentId == null ? ROOT_PARENT_ID : String.valueOf(parentId);
+        String key = properties.getKey() + ":parent:" + parentKey;
+        if (version == null || version.isBlank()) {
+            return key;
+        }
+        return version + ":" + key;
+    }
+
+    private RegionCachePayload toPayload(RegionListResponse response) {
+        List<RegionCacheItem> regions = response.getRegions().stream()
+                .map(item -> new RegionCacheItem(
+                        item.getRegionId(),
+                        item.getName(),
+                        item.getLevel(),
+                        item.getParentRegionId()
+                ))
+                .toList();
+        return new RegionCachePayload(regions);
+    }
+
+    private RegionListResponse fromPayload(RegionCachePayload payload) {
+        if (payload == null || payload.getRegions() == null) {
+            return RegionListResponse.of(List.of());
+        }
+        List<RegionResponse> regions = payload.getRegions().stream()
+                .map(item -> RegionResponse.of(
+                        item.getRegionId(),
+                        item.getName(),
+                        item.getLevel(),
+                        item.getParentRegionId()
+                ))
+                .toList();
+        return RegionListResponse.of(regions);
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    private static class RegionCachePayload {
+        private List<RegionCacheItem> regions;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    private static class RegionCacheItem {
+        private Long regionId;
+        private String name;
+        private RegionLevel level;
+        private Long parentRegionId;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -107,3 +107,6 @@ cache:
   breed:
     key: ${CACHE_BREED_KEY:cache:breeds:all}
     key-version: ${CACHE_BREED_KEY_VERSION:${CACHE_DEFAULT_KEY_VERSION:v2}}
+  region:
+    key: ${CACHE_REGION_KEY:cache:regions}
+    key-version: ${CACHE_REGION_KEY_VERSION:${CACHE_DEFAULT_KEY_VERSION:v2}}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #142 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 지역 조회 API(GET /api/v3/users/regions)에 Redis 캐시를 적용
- parentId 기준으로 캐시 키를 분리해 루트/하위 지역 조회를 각각 캐시하도록 구성


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
