### PR TITLE
refactor: 랭킹 배치 범위 조회 사용하도록 변경(인덱스 사용할 수 있도록 수정)

### DIFF
--- a/src/main/java/com/daengddang/daengdong_map/repository/DogGlobalRankBatchRepository.java
+++ b/src/main/java/com/daengddang/daengdong_map/repository/DogGlobalRankBatchRepository.java
@@ -1,10 +1,11 @@
 package com.daengddang.daengdong_map.repository;
 
 import com.daengddang.daengdong_map.domain.ranking.RankingPeriodType;
+import java.time.LocalDateTime;
 
 public interface DogGlobalRankBatchRepository {
 
-    int upsertRanks(RankingPeriodType periodType, String periodValue);
+    int upsertRanks(RankingPeriodType periodType, String periodValue, LocalDateTime startAt, LocalDateTime endAt);
 
-    int deleteObsoleteRanks(RankingPeriodType periodType, String periodValue);
+    int deleteObsoleteRanks(RankingPeriodType periodType, String periodValue, LocalDateTime startAt, LocalDateTime endAt);
 }

--- a/src/main/java/com/daengddang/daengdong_map/repository/DogGlobalRankBatchRepositoryImpl.java
+++ b/src/main/java/com/daengddang/daengdong_map/repository/DogGlobalRankBatchRepositoryImpl.java
@@ -4,24 +4,17 @@ import com.daengddang.daengdong_map.domain.ranking.RankingPeriodType;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Query;
+import java.time.LocalDateTime;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public class DogGlobalRankBatchRepositoryImpl implements DogGlobalRankBatchRepository {
 
-    private static final String PERIOD_FILTER = """
-            (
-                (:periodType = 'YEAR' and to_char(w.ended_at, 'YYYY') = :periodValue)
-                or (:periodType = 'MONTH' and to_char(w.ended_at, 'YYYY-MM') = :periodValue)
-                or (:periodType = 'WEEK' and (to_char(w.ended_at, 'IYYY') || '-W' || to_char(w.ended_at, 'IW')) = :periodValue)
-            )
-            """;
-
     @PersistenceContext
     private EntityManager entityManager;
 
     @Override
-    public int upsertRanks(RankingPeriodType periodType, String periodValue) {
+    public int upsertRanks(RankingPeriodType periodType, String periodValue, LocalDateTime startAt, LocalDateTime endAt) {
         Query query = entityManager.createNativeQuery("""
                 with aggregated as (
                     select
@@ -31,7 +24,8 @@ public class DogGlobalRankBatchRepositoryImpl implements DogGlobalRankBatchRepos
                     where w.status = 'FINISHED'
                       and w.ended_at is not null
                       and w.distance is not null
-                      and """ + PERIOD_FILTER + """
+                      and w.ended_at >= :startAt
+                      and w.ended_at < :endAt
                     group by w.dog_id
                 ), ranked as (
                     select
@@ -61,12 +55,17 @@ public class DogGlobalRankBatchRepositoryImpl implements DogGlobalRankBatchRepos
                     total_distance = excluded.total_distance,
                     ranking = excluded.ranking
                 """);
-        bindCommonParams(query, periodType, periodValue);
+        bindCommonParams(query, periodType, periodValue, startAt, endAt);
         return query.executeUpdate();
     }
 
     @Override
-    public int deleteObsoleteRanks(RankingPeriodType periodType, String periodValue) {
+    public int deleteObsoleteRanks(
+            RankingPeriodType periodType,
+            String periodValue,
+            LocalDateTime startAt,
+            LocalDateTime endAt
+    ) {
         Query query = entityManager.createNativeQuery("""
                 delete from dog_global_rank dgr
                 where dgr.period_type = :periodType
@@ -78,15 +77,24 @@ public class DogGlobalRankBatchRepositoryImpl implements DogGlobalRankBatchRepos
                       and w.status = 'FINISHED'
                       and w.ended_at is not null
                       and w.distance is not null
-                      and """ + PERIOD_FILTER + """
+                      and w.ended_at >= :startAt
+                      and w.ended_at < :endAt
                 )
                 """);
-        bindCommonParams(query, periodType, periodValue);
+        bindCommonParams(query, periodType, periodValue, startAt, endAt);
         return query.executeUpdate();
     }
 
-    private void bindCommonParams(Query query, RankingPeriodType periodType, String periodValue) {
+    private void bindCommonParams(
+            Query query,
+            RankingPeriodType periodType,
+            String periodValue,
+            LocalDateTime startAt,
+            LocalDateTime endAt
+    ) {
         query.setParameter("periodType", periodType.name());
         query.setParameter("periodValue", periodValue);
+        query.setParameter("startAt", startAt);
+        query.setParameter("endAt", endAt);
     }
 }

--- a/src/main/java/com/daengddang/daengdong_map/repository/DogRankBatchRepository.java
+++ b/src/main/java/com/daengddang/daengdong_map/repository/DogRankBatchRepository.java
@@ -1,10 +1,11 @@
 package com.daengddang.daengdong_map.repository;
 
 import com.daengddang.daengdong_map.domain.ranking.RankingPeriodType;
+import java.time.LocalDateTime;
 
 public interface DogRankBatchRepository {
 
-    int upsertRanks(RankingPeriodType periodType, String periodValue);
+    int upsertRanks(RankingPeriodType periodType, String periodValue, LocalDateTime startAt, LocalDateTime endAt);
 
-    int deleteObsoleteRanks(RankingPeriodType periodType, String periodValue);
+    int deleteObsoleteRanks(RankingPeriodType periodType, String periodValue, LocalDateTime startAt, LocalDateTime endAt);
 }

--- a/src/main/java/com/daengddang/daengdong_map/repository/DogRankBatchRepositoryImpl.java
+++ b/src/main/java/com/daengddang/daengdong_map/repository/DogRankBatchRepositoryImpl.java
@@ -4,24 +4,17 @@ import com.daengddang.daengdong_map.domain.ranking.RankingPeriodType;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Query;
+import java.time.LocalDateTime;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public class DogRankBatchRepositoryImpl implements DogRankBatchRepository {
 
-    private static final String PERIOD_FILTER = """
-            (
-                (:periodType = 'YEAR' and to_char(w.ended_at, 'YYYY') = :periodValue)
-                or (:periodType = 'MONTH' and to_char(w.ended_at, 'YYYY-MM') = :periodValue)
-                or (:periodType = 'WEEK' and (to_char(w.ended_at, 'IYYY') || '-W' || to_char(w.ended_at, 'IW')) = :periodValue)
-            )
-            """;
-
     @PersistenceContext
     private EntityManager entityManager;
 
     @Override
-    public int upsertRanks(RankingPeriodType periodType, String periodValue) {
+    public int upsertRanks(RankingPeriodType periodType, String periodValue, LocalDateTime startAt, LocalDateTime endAt) {
         Query query = entityManager.createNativeQuery("""
                 with aggregated as (
                     select
@@ -37,7 +30,8 @@ public class DogRankBatchRepositoryImpl implements DogRankBatchRepository {
                       and u.region_id is not null
                       and d.status = 'ACTIVE'
                       and u.status = 'ACTIVE'
-                      and """ + PERIOD_FILTER + """
+                      and w.ended_at >= :startAt
+                      and w.ended_at < :endAt
                     group by d.dog_id, u.region_id
                 ), ranked as (
                     select
@@ -73,12 +67,12 @@ public class DogRankBatchRepositoryImpl implements DogRankBatchRepository {
                     total_distance = excluded.total_distance,
                     ranking = excluded.ranking
                 """);
-        bindCommonParams(query, periodType, periodValue);
+        bindCommonParams(query, periodType, periodValue, startAt, endAt);
         return query.executeUpdate();
     }
 
     @Override
-    public int deleteObsoleteRanks(RankingPeriodType periodType, String periodValue) {
+    public int deleteObsoleteRanks(RankingPeriodType periodType, String periodValue, LocalDateTime startAt, LocalDateTime endAt) {
         Query query = entityManager.createNativeQuery("""
                 delete from dog_rank dr
                 where dr.period_type = :periodType
@@ -96,15 +90,24 @@ public class DogRankBatchRepositoryImpl implements DogRankBatchRepository {
                       and u.region_id is not null
                       and d.status = 'ACTIVE'
                       and u.status = 'ACTIVE'
-                      and """ + PERIOD_FILTER + """
+                      and w.ended_at >= :startAt
+                      and w.ended_at < :endAt
                 )
                 """);
-        bindCommonParams(query, periodType, periodValue);
+        bindCommonParams(query, periodType, periodValue, startAt, endAt);
         return query.executeUpdate();
     }
 
-    private void bindCommonParams(Query query, RankingPeriodType periodType, String periodValue) {
+    private void bindCommonParams(
+            Query query,
+            RankingPeriodType periodType,
+            String periodValue,
+            LocalDateTime startAt,
+            LocalDateTime endAt
+    ) {
         query.setParameter("periodType", periodType.name());
         query.setParameter("periodValue", periodValue);
+        query.setParameter("startAt", startAt);
+        query.setParameter("endAt", endAt);
     }
 }

--- a/src/main/java/com/daengddang/daengdong_map/repository/RegionDogRankBatchRepository.java
+++ b/src/main/java/com/daengddang/daengdong_map/repository/RegionDogRankBatchRepository.java
@@ -1,10 +1,11 @@
 package com.daengddang.daengdong_map.repository;
 
 import com.daengddang.daengdong_map.domain.ranking.RankingPeriodType;
+import java.time.LocalDateTime;
 
 public interface RegionDogRankBatchRepository {
 
-    int upsertRanks(RankingPeriodType periodType, String periodValue);
+    int upsertRanks(RankingPeriodType periodType, String periodValue, LocalDateTime startAt, LocalDateTime endAt);
 
-    int deleteObsoleteRanks(RankingPeriodType periodType, String periodValue);
+    int deleteObsoleteRanks(RankingPeriodType periodType, String periodValue, LocalDateTime startAt, LocalDateTime endAt);
 }

--- a/src/main/java/com/daengddang/daengdong_map/repository/RegionDogRankBatchRepositoryImpl.java
+++ b/src/main/java/com/daengddang/daengdong_map/repository/RegionDogRankBatchRepositoryImpl.java
@@ -4,24 +4,17 @@ import com.daengddang.daengdong_map.domain.ranking.RankingPeriodType;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Query;
+import java.time.LocalDateTime;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public class RegionDogRankBatchRepositoryImpl implements RegionDogRankBatchRepository {
 
-    private static final String PERIOD_FILTER = """
-            (
-                (:periodType = 'YEAR' and to_char(w.ended_at, 'YYYY') = :periodValue)
-                or (:periodType = 'MONTH' and to_char(w.ended_at, 'YYYY-MM') = :periodValue)
-                or (:periodType = 'WEEK' and (to_char(w.ended_at, 'IYYY') || '-W' || to_char(w.ended_at, 'IW')) = :periodValue)
-            )
-            """;
-
     @PersistenceContext
     private EntityManager entityManager;
 
     @Override
-    public int upsertRanks(RankingPeriodType periodType, String periodValue) {
+    public int upsertRanks(RankingPeriodType periodType, String periodValue, LocalDateTime startAt, LocalDateTime endAt) {
         Query query = entityManager.createNativeQuery("""
                 with dog_region_aggregated as (
                     select
@@ -37,7 +30,8 @@ public class RegionDogRankBatchRepositoryImpl implements RegionDogRankBatchRepos
                       and u.region_id is not null
                       and d.status = 'ACTIVE'
                       and u.status = 'ACTIVE'
-                      and """ + PERIOD_FILTER + """
+                      and w.ended_at >= :startAt
+                      and w.ended_at < :endAt
                     group by d.dog_id, u.region_id
                 ), region_total as (
                     select
@@ -92,12 +86,12 @@ public class RegionDogRankBatchRepositoryImpl implements RegionDogRankBatchRepos
                     contribution_rate = excluded.contribution_rate,
                     ranking = excluded.ranking
                 """);
-        bindCommonParams(query, periodType, periodValue);
+        bindCommonParams(query, periodType, periodValue, startAt, endAt);
         return query.executeUpdate();
     }
 
     @Override
-    public int deleteObsoleteRanks(RankingPeriodType periodType, String periodValue) {
+    public int deleteObsoleteRanks(RankingPeriodType periodType, String periodValue, LocalDateTime startAt, LocalDateTime endAt) {
         Query query = entityManager.createNativeQuery("""
                 delete from region_dog_rank rdr
                 where rdr.period_type = :periodType
@@ -115,15 +109,24 @@ public class RegionDogRankBatchRepositoryImpl implements RegionDogRankBatchRepos
                       and u.region_id is not null
                       and d.status = 'ACTIVE'
                       and u.status = 'ACTIVE'
-                      and """ + PERIOD_FILTER + """
+                      and w.ended_at >= :startAt
+                      and w.ended_at < :endAt
                 )
                 """);
-        bindCommonParams(query, periodType, periodValue);
+        bindCommonParams(query, periodType, periodValue, startAt, endAt);
         return query.executeUpdate();
     }
 
-    private void bindCommonParams(Query query, RankingPeriodType periodType, String periodValue) {
+    private void bindCommonParams(
+            Query query,
+            RankingPeriodType periodType,
+            String periodValue,
+            LocalDateTime startAt,
+            LocalDateTime endAt
+    ) {
         query.setParameter("periodType", periodType.name());
         query.setParameter("periodValue", periodValue);
+        query.setParameter("startAt", startAt);
+        query.setParameter("endAt", endAt);
     }
 }

--- a/src/main/java/com/daengddang/daengdong_map/repository/RegionRankBatchRepository.java
+++ b/src/main/java/com/daengddang/daengdong_map/repository/RegionRankBatchRepository.java
@@ -1,10 +1,11 @@
 package com.daengddang.daengdong_map.repository;
 
 import com.daengddang.daengdong_map.domain.ranking.RankingPeriodType;
+import java.time.LocalDateTime;
 
 public interface RegionRankBatchRepository {
 
-    int upsertRanks(RankingPeriodType periodType, String periodValue);
+    int upsertRanks(RankingPeriodType periodType, String periodValue, LocalDateTime startAt, LocalDateTime endAt);
 
-    int deleteObsoleteRanks(RankingPeriodType periodType, String periodValue);
+    int deleteObsoleteRanks(RankingPeriodType periodType, String periodValue, LocalDateTime startAt, LocalDateTime endAt);
 }

--- a/src/main/java/com/daengddang/daengdong_map/repository/RegionRankBatchRepositoryImpl.java
+++ b/src/main/java/com/daengddang/daengdong_map/repository/RegionRankBatchRepositoryImpl.java
@@ -4,24 +4,17 @@ import com.daengddang.daengdong_map.domain.ranking.RankingPeriodType;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Query;
+import java.time.LocalDateTime;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public class RegionRankBatchRepositoryImpl implements RegionRankBatchRepository {
 
-    private static final String PERIOD_FILTER = """
-            (
-                (:periodType = 'YEAR' and to_char(w.ended_at, 'YYYY') = :periodValue)
-                or (:periodType = 'MONTH' and to_char(w.ended_at, 'YYYY-MM') = :periodValue)
-                or (:periodType = 'WEEK' and (to_char(w.ended_at, 'IYYY') || '-W' || to_char(w.ended_at, 'IW')) = :periodValue)
-            )
-            """;
-
     @PersistenceContext
     private EntityManager entityManager;
 
     @Override
-    public int upsertRanks(RankingPeriodType periodType, String periodValue) {
+    public int upsertRanks(RankingPeriodType periodType, String periodValue, LocalDateTime startAt, LocalDateTime endAt) {
         Query query = entityManager.createNativeQuery("""
                 with aggregated as (
                     select
@@ -36,7 +29,8 @@ public class RegionRankBatchRepositoryImpl implements RegionRankBatchRepository 
                       and u.region_id is not null
                       and d.status = 'ACTIVE'
                       and u.status = 'ACTIVE'
-                      and """ + PERIOD_FILTER + """
+                      and w.ended_at >= :startAt
+                      and w.ended_at < :endAt
                     group by u.region_id
                 ), ranked as (
                     select
@@ -66,12 +60,12 @@ public class RegionRankBatchRepositoryImpl implements RegionRankBatchRepository 
                     total_distance = excluded.total_distance,
                     ranking = excluded.ranking
                 """);
-        bindCommonParams(query, periodType, periodValue);
+        bindCommonParams(query, periodType, periodValue, startAt, endAt);
         return query.executeUpdate();
     }
 
     @Override
-    public int deleteObsoleteRanks(RankingPeriodType periodType, String periodValue) {
+    public int deleteObsoleteRanks(RankingPeriodType periodType, String periodValue, LocalDateTime startAt, LocalDateTime endAt) {
         Query query = entityManager.createNativeQuery("""
                 delete from region_rank rr
                 where rr.period_type = :periodType
@@ -88,15 +82,24 @@ public class RegionRankBatchRepositoryImpl implements RegionRankBatchRepository 
                       and u.region_id is not null
                       and d.status = 'ACTIVE'
                       and u.status = 'ACTIVE'
-                      and """ + PERIOD_FILTER + """
+                      and w.ended_at >= :startAt
+                      and w.ended_at < :endAt
                 )
                 """);
-        bindCommonParams(query, periodType, periodValue);
+        bindCommonParams(query, periodType, periodValue, startAt, endAt);
         return query.executeUpdate();
     }
 
-    private void bindCommonParams(Query query, RankingPeriodType periodType, String periodValue) {
+    private void bindCommonParams(
+            Query query,
+            RankingPeriodType periodType,
+            String periodValue,
+            LocalDateTime startAt,
+            LocalDateTime endAt
+    ) {
         query.setParameter("periodType", periodType.name());
         query.setParameter("periodValue", periodValue);
+        query.setParameter("startAt", startAt);
+        query.setParameter("endAt", endAt);
     }
 }

--- a/src/main/java/com/daengddang/daengdong_map/service/ranking/batch/PeriodRange.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/ranking/batch/PeriodRange.java
@@ -1,0 +1,6 @@
+package com.daengddang.daengdong_map.service.ranking.batch;
+
+import java.time.LocalDateTime;
+
+public record PeriodRange(LocalDateTime startAt, LocalDateTime endAt) {
+}

--- a/src/main/java/com/daengddang/daengdong_map/service/ranking/batch/RankingBatchService.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/ranking/batch/RankingBatchService.java
@@ -43,31 +43,50 @@ public class RankingBatchService {
     }
 
     private void runUpsertByPeriodType(RankingPeriodType periodType) {
-        String periodValue = rankingPeriodResolver.resolveCurrentPeriodValue(periodType);
-        log.info("Ranking upsert period start. periodType={}, periodValue={}", periodType, periodValue);
+        PeriodRange periodRange = rankingPeriodResolver.resolveCurrentPeriodRange(periodType);
+        String periodValue = rankingPeriodResolver.resolvePeriodValue(periodType, periodRange);
+        log.info(
+                "Ranking upsert period start. periodType={}, periodValue={}, startAt={}, endAt={}",
+                periodType,
+                periodValue,
+                periodRange.startAt(),
+                periodRange.endAt()
+        );
 
-        runDogGlobalRankingUpsert(periodType, periodValue);
-        runDogRegionRankingUpsert(periodType, periodValue);
-        runRegionRankingUpsert(periodType, periodValue);
-        runRegionContributionRankingUpsert(periodType, periodValue);
+        runDogGlobalRankingUpsert(periodType, periodValue, periodRange);
+        runDogRegionRankingUpsert(periodType, periodValue, periodRange);
+        runRegionRankingUpsert(periodType, periodValue, periodRange);
+        runRegionContributionRankingUpsert(periodType, periodValue, periodRange);
 
         log.info("Ranking upsert period finished. periodType={}, periodValue={}", periodType, periodValue);
     }
 
     private void runCleanupByPeriodType(RankingPeriodType periodType) {
-        String periodValue = rankingPeriodResolver.resolveCurrentPeriodValue(periodType);
-        log.info("Ranking cleanup period start. periodType={}, periodValue={}", periodType, periodValue);
+        PeriodRange periodRange = rankingPeriodResolver.resolveCurrentPeriodRange(periodType);
+        String periodValue = rankingPeriodResolver.resolvePeriodValue(periodType, periodRange);
+        log.info(
+                "Ranking cleanup period start. periodType={}, periodValue={}, startAt={}, endAt={}",
+                periodType,
+                periodValue,
+                periodRange.startAt(),
+                periodRange.endAt()
+        );
 
-        runDogGlobalRankingCleanup(periodType, periodValue);
-        runDogRegionRankingCleanup(periodType, periodValue);
-        runRegionRankingCleanup(periodType, periodValue);
-        runRegionContributionRankingCleanup(periodType, periodValue);
+        runDogGlobalRankingCleanup(periodType, periodValue, periodRange);
+        runDogRegionRankingCleanup(periodType, periodValue, periodRange);
+        runRegionRankingCleanup(periodType, periodValue, periodRange);
+        runRegionContributionRankingCleanup(periodType, periodValue, periodRange);
 
         log.info("Ranking cleanup period finished. periodType={}, periodValue={}", periodType, periodValue);
     }
 
-    private void runDogGlobalRankingUpsert(RankingPeriodType periodType, String periodValue) {
-        int upserted = dogGlobalRankBatchRepository.upsertRanks(periodType, periodValue);
+    private void runDogGlobalRankingUpsert(RankingPeriodType periodType, String periodValue, PeriodRange periodRange) {
+        int upserted = dogGlobalRankBatchRepository.upsertRanks(
+                periodType,
+                periodValue,
+                periodRange.startAt(),
+                periodRange.endAt()
+        );
         log.info(
                 "Dog global ranking upsert completed. periodType={}, periodValue={}, upserted={}",
                 periodType,
@@ -76,8 +95,13 @@ public class RankingBatchService {
         );
     }
 
-    private void runDogGlobalRankingCleanup(RankingPeriodType periodType, String periodValue) {
-        int deleted = dogGlobalRankBatchRepository.deleteObsoleteRanks(periodType, periodValue);
+    private void runDogGlobalRankingCleanup(RankingPeriodType periodType, String periodValue, PeriodRange periodRange) {
+        int deleted = dogGlobalRankBatchRepository.deleteObsoleteRanks(
+                periodType,
+                periodValue,
+                periodRange.startAt(),
+                periodRange.endAt()
+        );
         log.info(
                 "Dog global ranking cleanup completed. periodType={}, periodValue={}, deleted={}",
                 periodType,
@@ -86,8 +110,13 @@ public class RankingBatchService {
         );
     }
 
-    private void runDogRegionRankingUpsert(RankingPeriodType periodType, String periodValue) {
-        int upserted = dogRankBatchRepository.upsertRanks(periodType, periodValue);
+    private void runDogRegionRankingUpsert(RankingPeriodType periodType, String periodValue, PeriodRange periodRange) {
+        int upserted = dogRankBatchRepository.upsertRanks(
+                periodType,
+                periodValue,
+                periodRange.startAt(),
+                periodRange.endAt()
+        );
         log.info(
                 "Dog region ranking upsert completed. periodType={}, periodValue={}, upserted={}",
                 periodType,
@@ -96,8 +125,13 @@ public class RankingBatchService {
         );
     }
 
-    private void runDogRegionRankingCleanup(RankingPeriodType periodType, String periodValue) {
-        int deleted = dogRankBatchRepository.deleteObsoleteRanks(periodType, periodValue);
+    private void runDogRegionRankingCleanup(RankingPeriodType periodType, String periodValue, PeriodRange periodRange) {
+        int deleted = dogRankBatchRepository.deleteObsoleteRanks(
+                periodType,
+                periodValue,
+                periodRange.startAt(),
+                periodRange.endAt()
+        );
         log.info(
                 "Dog region ranking cleanup completed. periodType={}, periodValue={}, deleted={}",
                 periodType,
@@ -106,8 +140,13 @@ public class RankingBatchService {
         );
     }
 
-    private void runRegionRankingUpsert(RankingPeriodType periodType, String periodValue) {
-        int upserted = regionRankBatchRepository.upsertRanks(periodType, periodValue);
+    private void runRegionRankingUpsert(RankingPeriodType periodType, String periodValue, PeriodRange periodRange) {
+        int upserted = regionRankBatchRepository.upsertRanks(
+                periodType,
+                periodValue,
+                periodRange.startAt(),
+                periodRange.endAt()
+        );
         log.info(
                 "Region ranking upsert completed. periodType={}, periodValue={}, upserted={}",
                 periodType,
@@ -116,8 +155,13 @@ public class RankingBatchService {
         );
     }
 
-    private void runRegionRankingCleanup(RankingPeriodType periodType, String periodValue) {
-        int deleted = regionRankBatchRepository.deleteObsoleteRanks(periodType, periodValue);
+    private void runRegionRankingCleanup(RankingPeriodType periodType, String periodValue, PeriodRange periodRange) {
+        int deleted = regionRankBatchRepository.deleteObsoleteRanks(
+                periodType,
+                periodValue,
+                periodRange.startAt(),
+                periodRange.endAt()
+        );
         log.info(
                 "Region ranking cleanup completed. periodType={}, periodValue={}, deleted={}",
                 periodType,
@@ -126,8 +170,17 @@ public class RankingBatchService {
         );
     }
 
-    private void runRegionContributionRankingUpsert(RankingPeriodType periodType, String periodValue) {
-        int upserted = regionDogRankBatchRepository.upsertRanks(periodType, periodValue);
+    private void runRegionContributionRankingUpsert(
+            RankingPeriodType periodType,
+            String periodValue,
+            PeriodRange periodRange
+    ) {
+        int upserted = regionDogRankBatchRepository.upsertRanks(
+                periodType,
+                periodValue,
+                periodRange.startAt(),
+                periodRange.endAt()
+        );
         log.info(
                 "Region contribution ranking upsert completed. periodType={}, periodValue={}, upserted={}",
                 periodType,
@@ -136,8 +189,17 @@ public class RankingBatchService {
         );
     }
 
-    private void runRegionContributionRankingCleanup(RankingPeriodType periodType, String periodValue) {
-        int deleted = regionDogRankBatchRepository.deleteObsoleteRanks(periodType, periodValue);
+    private void runRegionContributionRankingCleanup(
+            RankingPeriodType periodType,
+            String periodValue,
+            PeriodRange periodRange
+    ) {
+        int deleted = regionDogRankBatchRepository.deleteObsoleteRanks(
+                periodType,
+                periodValue,
+                periodRange.startAt(),
+                periodRange.endAt()
+        );
         log.info(
                 "Region contribution ranking cleanup completed. periodType={}, periodValue={}, deleted={}",
                 periodType,

--- a/src/main/java/com/daengddang/daengdong_map/service/ranking/batch/RankingPeriodResolver.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/ranking/batch/RankingPeriodResolver.java
@@ -1,9 +1,12 @@
 package com.daengddang.daengdong_map.service.ranking.batch;
 
 import com.daengddang.daengdong_map.domain.ranking.RankingPeriodType;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.IsoFields;
+import java.time.temporal.TemporalAdjusters;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -11,11 +14,23 @@ public class RankingPeriodResolver {
 
     private static final ZoneId BATCH_ZONE = ZoneId.of("Asia/Seoul");
 
-    public String resolveCurrentPeriodValue(RankingPeriodType periodType) {
-        return resolvePeriodValue(periodType, LocalDate.now(BATCH_ZONE));
+    public PeriodRange resolveCurrentPeriodRange(RankingPeriodType periodType) {
+        return resolvePeriodRange(periodType, LocalDate.now(BATCH_ZONE));
     }
 
-    public String resolvePeriodValue(RankingPeriodType periodType, LocalDate date) {
+    public PeriodRange resolvePeriodRange(RankingPeriodType periodType, LocalDate date) {
+        return switch (periodType) {
+            case YEAR -> from(date.withDayOfYear(1), date.plusYears(1).withDayOfYear(1));
+            case MONTH -> from(date.withDayOfMonth(1), date.plusMonths(1).withDayOfMonth(1));
+            case WEEK -> {
+                LocalDate weekStart = date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+                yield from(weekStart, weekStart.plusWeeks(1));
+            }
+        };
+    }
+
+    public String resolvePeriodValue(RankingPeriodType periodType, PeriodRange periodRange) {
+        LocalDate date = periodRange.startAt().toLocalDate();
         return switch (periodType) {
             case YEAR -> String.format("%04d", date.getYear());
             case MONTH -> String.format("%04d-%02d", date.getYear(), date.getMonthValue());
@@ -25,5 +40,9 @@ public class RankingPeriodResolver {
                     date.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR)
             );
         };
+    }
+
+    private PeriodRange from(LocalDate startDate, LocalDate endDate) {
+        return new PeriodRange(startDate.atStartOfDay(), endDate.atStartOfDay());
     }
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -26,4 +26,4 @@ ratelimit:
   enabled: false
 ranking:
   batch:
-    cron: "0 */30 * * * *"
+    cron: "0 * * * * *"


### PR DESCRIPTION
## #️⃣연관된 이슈

  > #153 

  ## 📝작업 내용

  > 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

  - 랭킹 배치 기간 필터를 문자열 변환(`to_char`) 기반에서 Range 조건 기반으로 변경했습니다.
    - `ended_at >= :startAt AND ended_at < :endAt`
  - `RankingPeriodResolver`에 기간 범위 계산 로직을 추가하고, `PeriodRange`를 도입
  - 기존 배치 리포지토리 메서드 시그니처를 periodValue 중심에서 `startAt/endAt` 중심으로 변경

  ### 스크린샷 (선택)

  ## 💬리뷰 요구사항(선택)

  > 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

  ———
