### PR TITLE
Fix: CI에서 environment 제거

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -31,15 +31,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
-    environment:
-      name: >-
-        ${{
-          (github.event_name == 'pull_request' && github.base_ref == 'main') && 'prod' ||
-          (github.event_name == 'pull_request') && 'dev' ||
-          (github.ref_name == 'main' && 'prod') ||
-          'dev'
-        }}
-
     steps:
       - name: Mark CI start
         id: ci_time


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- CI에서 environment 제거
    - main 브랜치론 dev 브랜치에서만 머지할 수 있도록 했는데
    - CI Job에서 environment를 prod로 잡는 케이스가 PR에서도 발생해서 GitHub Environment 보호 규칙에 걸렸었음
    - 그래서 CI에서 environment 제거

### 스크린샷 (선택)

<img width="906" height="581" alt="image" src="https://github.com/user-attachments/assets/c7039ac1-ee8d-46b2-b100-5753c79dd3bd" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
