### PR TITLE
feat: FastApi 작업 백프레셔 도입

### DIFF
--- a/src/main/java/com/daengddang/daengdong_map/analysis/AnalysisBackpressureGuard.java
+++ b/src/main/java/com/daengddang/daengdong_map/analysis/AnalysisBackpressureGuard.java
@@ -1,0 +1,29 @@
+package com.daengddang.daengdong_map.analysis;
+
+import com.daengddang.daengdong_map.common.exception.AnalysisBackpressureException;
+import com.daengddang.daengdong_map.repository.ExternalAnalysisTaskRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AnalysisBackpressureGuard {
+
+    private final AnalysisBackpressureProperties properties;
+    private final ExternalAnalysisTaskRepository externalAnalysisTaskRepository;
+
+    public void validateOrThrow() {
+        if (!properties.isEnabled()) {
+            return;
+        }
+
+        long activeTasks = externalAnalysisTaskRepository.countActiveTasks();
+        if (activeTasks >= properties.getMaxActiveTasks()) {
+            throw new AnalysisBackpressureException(
+                    properties.getRetryAfterSeconds(),
+                    activeTasks,
+                    properties.getMaxActiveTasks()
+            );
+        }
+    }
+}

--- a/src/main/java/com/daengddang/daengdong_map/analysis/AnalysisBackpressureProperties.java
+++ b/src/main/java/com/daengddang/daengdong_map/analysis/AnalysisBackpressureProperties.java
@@ -1,0 +1,17 @@
+package com.daengddang.daengdong_map.analysis;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "analysis.backpressure")
+public class AnalysisBackpressureProperties {
+
+    private boolean enabled = true;
+
+    private int maxActiveTasks = 180;
+
+    private int retryAfterSeconds = 3;
+}

--- a/src/main/java/com/daengddang/daengdong_map/common/exception/AnalysisBackpressureException.java
+++ b/src/main/java/com/daengddang/daengdong_map/common/exception/AnalysisBackpressureException.java
@@ -1,0 +1,19 @@
+package com.daengddang.daengdong_map.common.exception;
+
+import com.daengddang.daengdong_map.common.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AnalysisBackpressureException extends BaseException {
+
+    private final int retryAfterSeconds;
+    private final long activeTasks;
+    private final int maxActiveTasks;
+
+    public AnalysisBackpressureException(int retryAfterSeconds, long activeTasks, int maxActiveTasks) {
+        super(ErrorCode.TOO_MANY_REQUESTS);
+        this.retryAfterSeconds = retryAfterSeconds;
+        this.activeTasks = activeTasks;
+        this.maxActiveTasks = maxActiveTasks;
+    }
+}

--- a/src/main/java/com/daengddang/daengdong_map/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/daengddang/daengdong_map/common/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.daengddang.daengdong_map.common.ErrorCode;
 import org.hibernate.exception.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -17,6 +18,18 @@ import org.springframework.validation.FieldError;
 @RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(AnalysisBackpressureException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAnalysisBackpressureException(AnalysisBackpressureException e) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.RETRY_AFTER, String.valueOf(e.getRetryAfterSeconds()));
+        log.info("분석 백프레셔로 요청을 거절했습니다. activeTasks={}, maxActiveTasks={}, retryAfterSeconds={}",
+                e.getActiveTasks(), e.getMaxActiveTasks(), e.getRetryAfterSeconds());
+        return ResponseEntity
+                .status(ErrorCode.TOO_MANY_REQUESTS.getHttpStatus())
+                .headers(headers)
+                .body(ApiResponse.error(ErrorCode.TOO_MANY_REQUESTS));
+    }
 
     @ExceptionHandler(BaseException.class)
     public ResponseEntity<ApiResponse<Void>> handleBaseException(BaseException e) {

--- a/src/main/java/com/daengddang/daengdong_map/config/FastApiConfig.java
+++ b/src/main/java/com/daengddang/daengdong_map/config/FastApiConfig.java
@@ -1,10 +1,11 @@
 package com.daengddang.daengdong_map.config;
 
+import com.daengddang.daengdong_map.analysis.AnalysisBackpressureProperties;
 import com.daengddang.daengdong_map.ai.FastApiProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties(FastApiProperties.class)
+@EnableConfigurationProperties({FastApiProperties.class, AnalysisBackpressureProperties.class})
 public class FastApiConfig {
 }

--- a/src/main/java/com/daengddang/daengdong_map/repository/ExternalAnalysisTaskRepository.java
+++ b/src/main/java/com/daengddang/daengdong_map/repository/ExternalAnalysisTaskRepository.java
@@ -47,6 +47,8 @@ public interface ExternalAnalysisTaskRepository extends JpaRepository<ExternalAn
             Pageable pageable
     );
 
+    long countByStatusIn(List<ExternalAnalysisTaskStatus> statuses);
+
     default Optional<ExternalAnalysisTask> findLatestByWalkIdAndType(Long walkId, ExternalAnalysisTaskType type) {
         return findTopByWalkIdAndTypeOrderByRequestedAtDescIdDesc(walkId, type);
     }
@@ -72,6 +74,10 @@ public interface ExternalAnalysisTaskRepository extends JpaRepository<ExternalAn
                 ExternalAnalysisTaskStatus.PENDING,
                 PageRequest.of(0, batchSize)
         );
+    }
+
+    default long countActiveTasks() {
+        return countByStatusIn(List.of(ExternalAnalysisTaskStatus.PENDING, ExternalAnalysisTaskStatus.RUNNING));
     }
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)

--- a/src/main/java/com/daengddang/daengdong_map/service/ExternalAnalysisTaskService.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/ExternalAnalysisTaskService.java
@@ -1,5 +1,6 @@
 package com.daengddang.daengdong_map.service;
 
+import com.daengddang.daengdong_map.analysis.AnalysisBackpressureGuard;
 import com.daengddang.daengdong_map.common.ErrorCode;
 import com.daengddang.daengdong_map.common.exception.BaseException;
 import com.daengddang.daengdong_map.domain.dog.Dog;
@@ -27,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ExternalAnalysisTaskService {
 
+    private final AnalysisBackpressureGuard analysisBackpressureGuard;
     private final AccessValidator accessValidator;
     private final MissionUploadRepository missionUploadRepository;
     private final ExternalAnalysisTaskRepository externalAnalysisTaskRepository;
@@ -34,6 +36,7 @@ public class ExternalAnalysisTaskService {
 
     @Transactional
     public AnalysisTaskAcceptedResponse createMissionTask(Long userId, Long walkId) {
+        analysisBackpressureGuard.validateOrThrow();
         Walk walk = accessValidator.getOwnedWalkOrThrow(userId, walkId);
         if (walk.getStatus() != WalkStatus.FINISHED) {
             throw new BaseException(ErrorCode.INVALID_FORMAT);
@@ -46,6 +49,7 @@ public class ExternalAnalysisTaskService {
 
     @Transactional
     public AnalysisTaskAcceptedResponse createExpressionTask(Long userId, Long walkId, ExpressionAnalyzeRequest dto) {
+        analysisBackpressureGuard.validateOrThrow();
         if (dto == null) {
             throw new BaseException(ErrorCode.INVALID_FORMAT);
         }
@@ -55,6 +59,7 @@ public class ExternalAnalysisTaskService {
 
     @Transactional
     public AnalysisTaskAcceptedResponse createHealthcareTask(Long userId, HealthcareAnalyzeRequest dto) {
+        analysisBackpressureGuard.validateOrThrow();
         if (dto == null) {
             throw new BaseException(ErrorCode.INVALID_FORMAT);
         }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -25,4 +25,7 @@ ratelimit:
   enabled: false
 ranking:
   batch:
-    cron: "0 */10 * * * *"
+    enabled: true
+    cron: "0 */30 * * * *"
+    cleanup-cron: "0 */30 * * * *"
+    retention-cron: "0 */30 * * * *"

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -26,4 +26,7 @@ ratelimit:
   enabled: false
 ranking:
   batch:
-    cron: "* * 0 * * *"
+    enabled: true
+    cron: "0 0 0 * * *"
+    cleanup-cron: "0 0 0 * * *"
+    retention-cron: "0 0 0 * * *"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -92,6 +92,10 @@ ranking:
     zone: Asia/Seoul
 
 analysis:
+  backpressure:
+    enabled: ${ANALYSIS_BACKPRESSURE_ENABLED:true}
+    max-active-tasks: ${ANALYSIS_BACKPRESSURE_MAX_ACTIVE_TASKS:180}
+    retry-after-seconds: ${ANALYSIS_BACKPRESSURE_RETRY_AFTER_SECONDS:3}
   async:
     executor:
       core-pool-size: ${ANALYSIS_ASYNC_CORE_POOL_SIZE:16}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #171 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 비동기 외부 분석 작업 enqueue 경로에 백프레셔를 적용
  - 활성 작업 수(`PENDING`, `RUNNING`)가 임계치 이상일 때 `429 TOO_MANY_REQUESTS`를 반환하도록 구성


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
