### PR TITLE
feat: 개인 랭킹 조회 redis 캐싱 적용

### DIFF
--- a/src/main/java/com/daengddang/daengdong_map/service/cache/RankingPersonalCacheMetrics.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/cache/RankingPersonalCacheMetrics.java
@@ -1,0 +1,139 @@
+package com.daengddang.daengdong_map.service.cache;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.concurrent.atomic.LongAdder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Getter
+public class RankingPersonalCacheMetrics {
+
+    private static final long LOG_EVERY = 100L;
+
+    private final LongAdder hit = new LongAdder();
+    private final LongAdder miss = new LongAdder();
+    private final LongAdder bypassDisabled = new LongAdder();
+    private final LongAdder fallbackError = new LongAdder();
+    private final LongAdder dbLoad = new LongAdder();
+    private final LongAdder readError = new LongAdder();
+    private final LongAdder writeError = new LongAdder();
+
+    private final Counter hitCounter;
+    private final Counter missCounter;
+    private final Counter bypassDisabledCounter;
+    private final Counter fallbackErrorCounter;
+    private final Counter dbLoadCounter;
+    private final Counter readErrorCounter;
+    private final Counter writeErrorCounter;
+
+    public RankingPersonalCacheMetrics(ObjectProvider<MeterRegistry> registryProvider) {
+        MeterRegistry registry = registryProvider.getIfAvailable();
+        if (registry == null) {
+            hitCounter = null;
+            missCounter = null;
+            bypassDisabledCounter = null;
+            fallbackErrorCounter = null;
+            dbLoadCounter = null;
+            readErrorCounter = null;
+            writeErrorCounter = null;
+            return;
+        }
+
+        hitCounter = Counter.builder("cache.ranking.personal.hit")
+                .description("Personal ranking cache hit count")
+                .register(registry);
+        missCounter = Counter.builder("cache.ranking.personal.miss")
+                .description("Personal ranking cache miss count")
+                .register(registry);
+        bypassDisabledCounter = Counter.builder("cache.ranking.personal.bypass.disabled")
+                .description("Personal ranking cache bypass count when cache is disabled")
+                .register(registry);
+        fallbackErrorCounter = Counter.builder("cache.ranking.personal.fallback.error")
+                .description("Personal ranking cache fallback-to-db count due to cache error")
+                .register(registry);
+        dbLoadCounter = Counter.builder("cache.ranking.personal.db.load")
+                .description("Personal ranking DB load count when cache miss/fallback occurs")
+                .register(registry);
+        readErrorCounter = Counter.builder("cache.ranking.personal.read.error")
+                .description("Personal ranking cache read error count")
+                .register(registry);
+        writeErrorCounter = Counter.builder("cache.ranking.personal.write.error")
+                .description("Personal ranking cache write error count")
+                .register(registry);
+    }
+
+    public void recordHit() {
+        hit.increment();
+        increment(hitCounter);
+        maybeLog();
+    }
+
+    public void recordMiss() {
+        miss.increment();
+        increment(missCounter);
+        maybeLog();
+    }
+
+    public void recordBypassDisabled() {
+        bypassDisabled.increment();
+        increment(bypassDisabledCounter);
+        maybeLog();
+    }
+
+    public void recordFallbackError() {
+        fallbackError.increment();
+        increment(fallbackErrorCounter);
+        maybeLog();
+    }
+
+    public void recordDbLoad() {
+        dbLoad.increment();
+        increment(dbLoadCounter);
+        maybeLog();
+    }
+
+    public void recordReadError() {
+        readError.increment();
+        increment(readErrorCounter);
+        maybeLog();
+    }
+
+    public void recordWriteError() {
+        writeError.increment();
+        increment(writeErrorCounter);
+        maybeLog();
+    }
+
+    private void maybeLog() {
+        long total = hit.sum() + miss.sum() + bypassDisabled.sum() + fallbackError.sum() + dbLoad.sum();
+        if (total > 0 && total % LOG_EVERY == 0) {
+            long hitCount = hit.sum();
+            long missCount = miss.sum();
+            double hitRatio = (hitCount + missCount) == 0
+                    ? 0.0
+                    : (hitCount * 100.0) / (hitCount + missCount);
+            log.info(
+                    "[RankingPersonalCacheMetrics] hit={}, miss={}, hitRatio={}%, bypassDisabled={}, fallbackError={}, dbLoad={}, readError={}, writeError={}",
+                    hitCount,
+                    missCount,
+                    String.format("%.2f", hitRatio),
+                    bypassDisabled.sum(),
+                    fallbackError.sum(),
+                    dbLoad.sum(),
+                    readError.sum(),
+                    writeError.sum()
+            );
+        }
+    }
+
+    private void increment(Counter counter) {
+        if (counter != null) {
+            counter.increment();
+        }
+    }
+}

--- a/src/main/java/com/daengddang/daengdong_map/service/cache/RankingPersonalCacheProperties.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/cache/RankingPersonalCacheProperties.java
@@ -1,0 +1,20 @@
+package com.daengddang.daengdong_map.service.cache;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "cache.ranking.personal")
+public class RankingPersonalCacheProperties {
+
+    private Boolean enabled;
+    private Long ttlSeconds;
+    private Integer jitterPercent;
+    private String keyVersion;
+    private String summaryKey = "cache:rankings:dogs:summary";
+    private String listKey = "cache:rankings:dogs:list";
+}

--- a/src/main/java/com/daengddang/daengdong_map/service/cache/RankingPersonalCacheStore.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/cache/RankingPersonalCacheStore.java
@@ -1,0 +1,322 @@
+package com.daengddang.daengdong_map.service.cache;
+
+import com.daengddang.daengdong_map.dto.response.ranking.personal.PersonalRankItemResponse;
+import com.daengddang.daengdong_map.dto.response.ranking.personal.PersonalRankingListResponse;
+import com.daengddang.daengdong_map.dto.response.ranking.personal.PersonalRankingSummaryResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.StringCodec;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingPersonalCacheStore {
+
+    private static final String NULL_REGION = "all";
+    private static final String NULL_USER = "anon";
+
+    private final RedissonClient redissonClient;
+    private final ObjectMapper objectMapper;
+    private final CacheDefaultProperties defaultProperties;
+    private final RankingPersonalCacheProperties properties;
+    private final RankingPersonalCacheMetrics metrics;
+
+    public Optional<PersonalRankingSummaryResponse> getSummary(String periodType,
+                                                               String periodValue,
+                                                               Long regionId,
+                                                               Long userId) {
+        if (!isEnabled()) {
+            metrics.recordBypassDisabled();
+            return Optional.empty();
+        }
+
+        try {
+            RBucket<String> bucket = redissonClient.getBucket(
+                    buildSummaryKey(periodType, periodValue, regionId, userId),
+                    StringCodec.INSTANCE
+            );
+            String cachedJson = bucket.get();
+            if (cachedJson == null || cachedJson.isBlank()) {
+                metrics.recordMiss();
+                return Optional.empty();
+            }
+            PersonalRankingSummaryPayload payload =
+                    objectMapper.readValue(cachedJson, PersonalRankingSummaryPayload.class);
+            metrics.recordHit();
+            return Optional.of(fromSummaryPayload(payload));
+        } catch (Exception e) {
+            metrics.recordReadError();
+            metrics.recordFallbackError();
+            log.warn("개인 랭킹 요약 캐시 조회 실패 (Personal ranking summary cache read failed)", e);
+            return Optional.empty();
+        }
+    }
+
+    public void putSummary(String periodType,
+                           String periodValue,
+                           Long regionId,
+                           Long userId,
+                           PersonalRankingSummaryResponse response) {
+        if (!isEnabled()) {
+            return;
+        }
+
+        try {
+            String key = buildSummaryKey(periodType, periodValue, regionId, userId);
+            String payload = objectMapper.writeValueAsString(toSummaryPayload(response));
+            redissonClient.getBucket(key, StringCodec.INSTANCE)
+                    .setAsync(payload, resolveTtlSeconds(), TimeUnit.SECONDS)
+                    .whenComplete((result, throwable) -> {
+                        if (throwable != null) {
+                            metrics.recordWriteError();
+                            log.warn("개인 랭킹 요약 캐시 저장 실패 (Personal ranking summary cache write failed)", throwable);
+                        }
+                    });
+        } catch (Exception e) {
+            metrics.recordWriteError();
+            log.warn("개인 랭킹 요약 캐시 저장 실패 (Personal ranking summary cache write failed)", e);
+        }
+    }
+
+    public Optional<PersonalRankingListResponse> getList(String periodType,
+                                                         String periodValue,
+                                                         Long regionId,
+                                                         String cursor,
+                                                         int limit) {
+        if (!isEnabled()) {
+            metrics.recordBypassDisabled();
+            return Optional.empty();
+        }
+
+        try {
+            RBucket<String> bucket = redissonClient.getBucket(
+                    buildListKey(periodType, periodValue, regionId, cursor, limit),
+                    StringCodec.INSTANCE
+            );
+            String cachedJson = bucket.get();
+            if (cachedJson == null || cachedJson.isBlank()) {
+                metrics.recordMiss();
+                return Optional.empty();
+            }
+            PersonalRankingListPayload payload =
+                    objectMapper.readValue(cachedJson, PersonalRankingListPayload.class);
+            metrics.recordHit();
+            return Optional.of(fromListPayload(payload));
+        } catch (Exception e) {
+            metrics.recordReadError();
+            metrics.recordFallbackError();
+            log.warn("개인 랭킹 목록 캐시 조회 실패 (Personal ranking list cache read failed)", e);
+            return Optional.empty();
+        }
+    }
+
+    public void putList(String periodType,
+                        String periodValue,
+                        Long regionId,
+                        String cursor,
+                        int limit,
+                        PersonalRankingListResponse response) {
+        if (!isEnabled()) {
+            return;
+        }
+
+        try {
+            String key = buildListKey(periodType, periodValue, regionId, cursor, limit);
+            String payload = objectMapper.writeValueAsString(toListPayload(response));
+            redissonClient.getBucket(key, StringCodec.INSTANCE)
+                    .setAsync(payload, resolveTtlSeconds(), TimeUnit.SECONDS)
+                    .whenComplete((result, throwable) -> {
+                        if (throwable != null) {
+                            metrics.recordWriteError();
+                            log.warn("개인 랭킹 목록 캐시 저장 실패 (Personal ranking list cache write failed)", throwable);
+                        }
+                    });
+        } catch (Exception e) {
+            metrics.recordWriteError();
+            log.warn("개인 랭킹 목록 캐시 저장 실패 (Personal ranking list cache write failed)", e);
+        }
+    }
+
+    public String buildSummaryKey(String periodType, String periodValue, Long regionId, Long userId) {
+        return resolvePrefix(properties.getSummaryKey())
+                + ":" + safe(periodType)
+                + ":" + safe(periodValue)
+                + ":" + resolveRegionPart(regionId)
+                + ":" + resolveUserPart(userId);
+    }
+
+    public String buildListKey(String periodType, String periodValue, Long regionId, String cursor, int limit) {
+        String rawCursor = cursor == null ? "" : cursor;
+        String cursorHash = sha256Hex(rawCursor);
+        return resolvePrefix(properties.getListKey())
+                + ":" + safe(periodType)
+                + ":" + safe(periodValue)
+                + ":" + resolveRegionPart(regionId)
+                + ":limit:" + limit
+                + ":cursor:" + cursorHash;
+    }
+
+    private long resolveTtlSeconds() {
+        long base = properties.getTtlSeconds() == null
+                ? defaultProperties.getTtlSeconds()
+                : properties.getTtlSeconds();
+        int jitterPercent = properties.getJitterPercent() == null
+                ? defaultProperties.getJitterPercent()
+                : properties.getJitterPercent();
+        jitterPercent = Math.max(0, Math.min(100, jitterPercent));
+        if (jitterPercent == 0 || base <= 0) {
+            return Math.max(1, base);
+        }
+
+        double ratio = jitterPercent / 100.0;
+        double min = base * (1 - ratio);
+        double max = base * (1 + ratio);
+        long ttl = Math.round(ThreadLocalRandom.current().nextDouble(min, max));
+        return Math.max(1, ttl);
+    }
+
+    private boolean isEnabled() {
+        return properties.getEnabled() == null
+                ? defaultProperties.isEnabled()
+                : properties.getEnabled();
+    }
+
+    private String resolvePrefix(String baseKey) {
+        String version = properties.getKeyVersion() == null
+                ? defaultProperties.getKeyVersion()
+                : properties.getKeyVersion();
+        if (version == null || version.isBlank()) {
+            return baseKey;
+        }
+        return version + ":" + baseKey;
+    }
+
+    private String resolveRegionPart(Long regionId) {
+        return regionId == null ? NULL_REGION : regionId.toString();
+    }
+
+    private String resolveUserPart(Long userId) {
+        return userId == null ? NULL_USER : userId.toString();
+    }
+
+    private String safe(String value) {
+        return value == null || value.isBlank() ? "none" : value;
+    }
+
+    private String sha256Hex(String input) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    private PersonalRankingSummaryPayload toSummaryPayload(PersonalRankingSummaryResponse response) {
+        return new PersonalRankingSummaryPayload(
+                response.getTopRanks().stream().map(this::toItem).toList(),
+                response.getMyRank() == null ? null : toItem(response.getMyRank())
+        );
+    }
+
+    private PersonalRankingSummaryResponse fromSummaryPayload(PersonalRankingSummaryPayload payload) {
+        List<PersonalRankItemResponse> topRanks = payload.getTopRanks() == null
+                ? List.of()
+                : payload.getTopRanks().stream().map(this::fromItem).toList();
+        PersonalRankItemResponse myRank = payload.getMyRank() == null ? null : fromItem(payload.getMyRank());
+        return PersonalRankingSummaryResponse.of(topRanks, myRank);
+    }
+
+    private PersonalRankingListPayload toListPayload(PersonalRankingListResponse response) {
+        return new PersonalRankingListPayload(
+                response.getRanks().stream().map(this::toItem).toList(),
+                response.getNextCursor(),
+                response.isHasNext()
+        );
+    }
+
+    private PersonalRankingListResponse fromListPayload(PersonalRankingListPayload payload) {
+        List<PersonalRankItemResponse> ranks = payload.getRanks() == null
+                ? List.of()
+                : payload.getRanks().stream().map(this::fromItem).toList();
+        return PersonalRankingListResponse.of(ranks, payload.getNextCursor(), payload.isHasNext());
+    }
+
+    private PersonalRankItemPayload toItem(PersonalRankItemResponse item) {
+        return new PersonalRankItemPayload(
+                item.getRank(),
+                item.getDogId(),
+                item.getDogName(),
+                item.getBirthDate(),
+                item.getProfileImageUrl(),
+                item.getBreed(),
+                item.getTotalDistance()
+        );
+    }
+
+    private PersonalRankItemResponse fromItem(PersonalRankItemPayload item) {
+        return PersonalRankItemResponse.of(
+                item.getRank(),
+                item.getDogId(),
+                item.getDogName(),
+                item.getBirthDate(),
+                item.getProfileImageUrl(),
+                item.getBreed(),
+                item.getTotalDistance()
+        );
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    private static class PersonalRankingSummaryPayload {
+        private List<PersonalRankItemPayload> topRanks;
+        private PersonalRankItemPayload myRank;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    private static class PersonalRankingListPayload {
+        private List<PersonalRankItemPayload> ranks;
+        private String nextCursor;
+        private boolean hasNext;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    private static class PersonalRankItemPayload {
+        private Integer rank;
+        private Long dogId;
+        private String dogName;
+        private LocalDate birthDate;
+        private String profileImageUrl;
+        private String breed;
+        private Double totalDistance;
+    }
+}

--- a/src/main/java/com/daengddang/daengdong_map/service/ranking/PersonalRankingService.java
+++ b/src/main/java/com/daengddang/daengdong_map/service/ranking/PersonalRankingService.java
@@ -10,12 +10,17 @@ import com.daengddang.daengdong_map.dto.response.ranking.personal.PersonalRankin
 import com.daengddang.daengdong_map.repository.DogGlobalRankRepository;
 import com.daengddang.daengdong_map.repository.DogRankRepository;
 import com.daengddang.daengdong_map.repository.projection.DogRankView;
+import com.daengddang.daengdong_map.service.cache.RankingPersonalCacheMetrics;
+import com.daengddang.daengdong_map.service.cache.RankingPersonalCacheStore;
 import com.daengddang.daengdong_map.util.AccessValidator;
 import com.daengddang.daengdong_map.util.RankingCursorCodec;
 import com.daengddang.daengdong_map.util.RankingRequestValidator;
 import com.daengddang.daengdong_map.util.RegionValidator;
 import com.daengddang.daengdong_map.util.RankingValidator;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -35,18 +40,77 @@ public class PersonalRankingService {
     private final RankingCursorCodec rankingCursorCodec;
     private final RegionValidator regionValidator;
     private final AccessValidator accessValidator;
+    private final RankingPersonalCacheStore rankingPersonalCacheStore;
+    private final RankingPersonalCacheMetrics rankingPersonalCacheMetrics;
+    private final ConcurrentHashMap<String, CompletableFuture<PersonalRankingSummaryResponse>> summaryInFlight =
+            new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, CompletableFuture<PersonalRankingListResponse>> listInFlight =
+            new ConcurrentHashMap<>();
 
     public PersonalRankingSummaryResponse getPersonalRankingSummary(Long userId, RankingPeriodRegionRequest dto) {
         rankingRequestValidator.validateRequestNotNull(dto);
         RankingPeriodType periodType = rankingRequestValidator.parseAndValidatePeriod(dto.getPeriodType(), dto.getPeriodValue());
-        Dog dog = userId != null ? accessValidator.getDogOrThrow(userId) : null;
         Long regionId = dto.getRegionId();
+
+        Optional<PersonalRankingSummaryResponse> cached = rankingPersonalCacheStore.getSummary(
+                periodType.name(),
+                dto.getPeriodValue(),
+                regionId,
+                userId
+        );
+        if (cached.isPresent()) {
+            return cached.get();
+        }
+
+        String inflightKey = rankingPersonalCacheStore.buildSummaryKey(
+                periodType.name(),
+                dto.getPeriodValue(),
+                regionId,
+                userId
+        );
+        return loadSummaryWithSingleFlight(inflightKey, userId, periodType, dto.getPeriodValue(), regionId);
+    }
+
+    private PersonalRankingSummaryResponse loadSummaryWithSingleFlight(String inflightKey,
+                                                                       Long userId,
+                                                                       RankingPeriodType periodType,
+                                                                       String periodValue,
+                                                                       Long regionId) {
+        while (true) {
+            CompletableFuture<PersonalRankingSummaryResponse> existing = summaryInFlight.get(inflightKey);
+            if (existing != null) {
+                return existing.join();
+            }
+
+            CompletableFuture<PersonalRankingSummaryResponse> created = new CompletableFuture<>();
+            if (summaryInFlight.putIfAbsent(inflightKey, created) == null) {
+                try {
+                    PersonalRankingSummaryResponse response = loadSummaryFromDb(userId, periodType, periodValue, regionId);
+                    rankingPersonalCacheStore.putSummary(periodType.name(), periodValue, regionId, userId, response);
+                    created.complete(response);
+                    return response;
+                } catch (Exception e) {
+                    created.completeExceptionally(e);
+                    throw e;
+                } finally {
+                    summaryInFlight.remove(inflightKey, created);
+                }
+            }
+        }
+    }
+
+    private PersonalRankingSummaryResponse loadSummaryFromDb(Long userId,
+                                                             RankingPeriodType periodType,
+                                                             String periodValue,
+                                                             Long regionId) {
+        rankingPersonalCacheMetrics.recordDbLoad();
+        Dog dog = userId != null ? accessValidator.getDogOrThrow(userId) : null;
 
         List<PersonalRankItemResponse> topRanks;
         PersonalRankItemResponse myRank;
         if (regionId == null) {
             topRanks = dogGlobalRankRepository
-                    .findRanks(periodType, dto.getPeriodValue(), PageRequest.of(0, SUMMARY_TOP_LIMIT))
+                    .findRanks(periodType, periodValue, PageRequest.of(0, SUMMARY_TOP_LIMIT))
                     .stream()
                     .map(this::toPersonalRankItem)
                     .toList();
@@ -54,13 +118,13 @@ public class PersonalRankingService {
             myRank = dog == null
                     ? null
                     : dogGlobalRankRepository
-                    .findMyRank(periodType, dto.getPeriodValue(), dog.getId())
+                    .findMyRank(periodType, periodValue, dog.getId())
                     .map(this::toPersonalRankItem)
                     .orElse(null);
         } else {
             regionValidator.validateActiveRegion(regionId);
             topRanks = dogRankRepository
-                    .findRanks(periodType, dto.getPeriodValue(), regionId, PageRequest.of(0, SUMMARY_TOP_LIMIT))
+                    .findRanks(periodType, periodValue, regionId, PageRequest.of(0, SUMMARY_TOP_LIMIT))
                     .stream()
                     .map(this::toPersonalRankItem)
                     .toList();
@@ -68,7 +132,7 @@ public class PersonalRankingService {
             myRank = dog == null
                     ? null
                     : dogRankRepository
-                    .findMyRank(periodType, dto.getPeriodValue(), regionId, dog.getId())
+                    .findMyRank(periodType, periodValue, regionId, dog.getId())
                     .map(this::toPersonalRankItem)
                     .orElse(null);
         }
@@ -89,24 +153,80 @@ public class PersonalRankingService {
         String cursor = rankingRequestValidator.resolveCursor(cursorRequest);
         int limit = rankingRequestValidator.resolveLimit(cursorRequest);
 
+        Optional<PersonalRankingListResponse> cached = rankingPersonalCacheStore.getList(
+                periodType.name(),
+                dto.getPeriodValue(),
+                regionId,
+                cursor,
+                limit
+        );
+        if (cached.isPresent()) {
+            return cached.get();
+        }
+
+        String inflightKey = rankingPersonalCacheStore.buildListKey(
+                periodType.name(),
+                dto.getPeriodValue(),
+                regionId,
+                cursor,
+                limit
+        );
+        return loadListWithSingleFlight(inflightKey, periodType, dto.getPeriodValue(), regionId, cursor, limit);
+    }
+
+    private PersonalRankingListResponse loadListWithSingleFlight(String inflightKey,
+                                                                 RankingPeriodType periodType,
+                                                                 String periodValue,
+                                                                 Long regionId,
+                                                                 String cursor,
+                                                                 int limit) {
+        while (true) {
+            CompletableFuture<PersonalRankingListResponse> existing = listInFlight.get(inflightKey);
+            if (existing != null) {
+                return existing.join();
+            }
+
+            CompletableFuture<PersonalRankingListResponse> created = new CompletableFuture<>();
+            if (listInFlight.putIfAbsent(inflightKey, created) == null) {
+                try {
+                    PersonalRankingListResponse response = loadListFromDb(periodType, periodValue, regionId, cursor, limit);
+                    rankingPersonalCacheStore.putList(periodType.name(), periodValue, regionId, cursor, limit, response);
+                    created.complete(response);
+                    return response;
+                } catch (Exception e) {
+                    created.completeExceptionally(e);
+                    throw e;
+                } finally {
+                    listInFlight.remove(inflightKey, created);
+                }
+            }
+        }
+    }
+
+    private PersonalRankingListResponse loadListFromDb(RankingPeriodType periodType,
+                                                       String periodValue,
+                                                       Long regionId,
+                                                       String cursor,
+                                                       int limit) {
+        rankingPersonalCacheMetrics.recordDbLoad();
         CursorPagingSupport.CursorPageResult<PersonalRankItemResponse> page = cursorPagingSupport.paginate(
                 cursor,
                 limit,
                 fetchSize -> regionId == null
-                        ? dogGlobalRankRepository.findRanks(periodType, dto.getPeriodValue(), PageRequest.of(0, fetchSize))
-                        : dogRankRepository.findRanks(periodType, dto.getPeriodValue(), regionId, PageRequest.of(0, fetchSize)),
+                        ? dogGlobalRankRepository.findRanks(periodType, periodValue, PageRequest.of(0, fetchSize))
+                        : dogRankRepository.findRanks(periodType, periodValue, regionId, PageRequest.of(0, fetchSize)),
                 RankingValidator::parseRankDogCursor,
                 (parsedCursor, pageLimit) -> regionId == null
                         ? dogGlobalRankRepository.findRanksByCursor(
                         periodType,
-                        dto.getPeriodValue(),
+                        periodValue,
                         parsedCursor.rank(),
                         parsedCursor.dogId(),
                         PageRequest.of(0, pageLimit)
                 )
                         : dogRankRepository.findRanksByCursor(
                         periodType,
-                        dto.getPeriodValue(),
+                        periodValue,
                         regionId,
                         parsedCursor.rank(),
                         parsedCursor.dogId(),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -142,3 +142,8 @@ cache:
   region:
     key: ${CACHE_REGION_KEY:cache:regions}
     key-version: ${CACHE_REGION_KEY_VERSION:${CACHE_DEFAULT_KEY_VERSION:v2}}
+  ranking:
+    personal:
+      summary-key: ${CACHE_RANKING_PERSONAL_SUMMARY_KEY:cache:rankings:dogs:summary}
+      list-key: ${CACHE_RANKING_PERSONAL_LIST_KEY:cache:rankings:dogs:list}
+      key-version: ${CACHE_RANKING_PERSONAL_KEY_VERSION:${CACHE_DEFAULT_KEY_VERSION:v2}}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #174 #176 

## 📝작업 내용
- 개인 랭킹 조회 API Redis 캐시 적용
- 적용 대상
  - `GET /api/v3/rankings/dogs/summary`
  - `GET /api/v3/rankings/dogs`

### 성능 비교 (300 VU, 2m)

| 항목 | 캐시 적용 전 | 캐시 적용 후 | 변화 |
| --- | ---: | ---: | ---: |
| summary p95 (ms) | 289.48 | 137.52 | -151.96 |
| list p95 (ms) | 251.78 | 129.66 | -122.12 |
| RPS | 1,511.82 | 3,002.23 | +1,490.41 |
| DB calls delta (주요 2개 쿼리 합) | +272,652 | +3 | -272,649 |

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

